### PR TITLE
Some improvements

### DIFF
--- a/Example/Tests/Mocks/MockedConfiguration.swift
+++ b/Example/Tests/Mocks/MockedConfiguration.swift
@@ -9,10 +9,10 @@
 import Cara
 
 class MockedConfiguration: Cara.Configuration {
-    var baseURL: URL
+    var baseURL: URL?
     var headers: RequestHeaders?
     
-    init(baseURL: URL, headers: RequestHeaders? = nil) {
+    init(baseURL: URL?, headers: RequestHeaders? = nil) {
         self.baseURL = baseURL
         self.headers = headers
     }

--- a/Example/Tests/Mocks/MockedSerializer.swift
+++ b/Example/Tests/Mocks/MockedSerializer.swift
@@ -20,8 +20,7 @@ struct MockedSerializer: Serializer {
     
     // MARK: - Serializer
     
-    func serialize(data: Data?, error: Error?, response: URLResponse?) -> MockedSerializer.Response {
-        let urlResponse = response as? HTTPURLResponse
-        return Response(data: data, error: error, statusCode: urlResponse?.statusCode)
+    func serialize(data: Data?, error: Error?, response: HTTPURLResponse?) -> MockedSerializer.Response {
+        return Response(data: data, error: error, statusCode: response?.statusCode)
     }
 }

--- a/Example/Tests/Specs/Request/RequestSpec.swift
+++ b/Example/Tests/Specs/Request/RequestSpec.swift
@@ -38,6 +38,14 @@ class RequestSpec: QuickSpec {
                     _ = try request.makeURLRequest(with: configuration)
                 }.to(throwError(ResponseError.invalidURL))
             }
+            
+            it("should throw an invalid url error when base url is missing") {
+                configuration = MockedConfiguration(baseURL: nil)
+                let request = MockedRequest(url: URL(string: "request"))
+                expect {
+                    _ = try request.makeURLRequest(with: configuration)
+                }.to(throwError(ResponseError.invalidURL))
+            }
         }
         
         context("method") {

--- a/Example/Tests/Specs/Service/ServiceSpec.swift
+++ b/Example/Tests/Specs/Service/ServiceSpec.swift
@@ -51,6 +51,32 @@ class ServiceSpec: QuickSpec {
                     }
                 }
             }
+            
+            context("task") {
+                it("should return a task when request is triggered") {
+                    self.stub(http(.get, uri: "https://relative.com/request"), http(200))
+                    
+                    let request = MockedRequest(url: URL(string: "request"))
+                    var task: URLSessionDataTask?
+                    waitUntil { done in
+                        task = service.execute(request, with: MockedSerializer()) { _ in
+                            done()
+                        }
+                    }
+                    expect(task).toNot(beNil())
+                }
+                
+                it("should not return a task when request fail to trigger") {
+                    let request = MockedRequest(url: nil)
+                    var task: URLSessionDataTask?
+                    waitUntil { done in
+                        task = service.execute(request, with: MockedSerializer()) { _ in
+                            done()
+                        }
+                    }
+                    expect(task).to(beNil())
+                }
+            }
          
             context("serializer") {
                 it("should fail to execute a request because of an invalid url") {

--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -8,7 +8,7 @@
 /// The configuration is used by the `Service` instance during the execution of the request.
 public protocol Configuration {
     /// The base url that is appended to the `Request`'s relative url.
-    var baseURL: URL { get }
+    var baseURL: URL? { get }
     /// Set the headers that will be used for all the requests.
     var headers: RequestHeaders? { get }
 }

--- a/Sources/Request/Request+URLRequest.swift
+++ b/Sources/Request/Request+URLRequest.swift
@@ -23,8 +23,10 @@ extension Request {
         guard let url = url else { throw ResponseError.invalidURL }
         // When the url is an absolure url, just use this url.
         guard url.host == nil else { return url.appendingQuery(from: self) }
+        // When the url is a relative url we should have a base url defined.
+        guard let baseURL = configuration.baseURL else { throw ResponseError.invalidURL }
         // Return the relative url appended to the base url.
-        return configuration.baseURL.appendingPathComponent(url.absoluteString).appendingQuery(from: self)
+        return baseURL.appendingPathComponent(url.absoluteString).appendingQuery(from: self)
     }
     
     private func makeHeaders(with configuration: Configuration) -> RequestHeaders? {

--- a/Sources/Serializer/CodableSerializer.swift
+++ b/Sources/Serializer/CodableSerializer.swift
@@ -26,7 +26,7 @@ public struct CodableSerializer<Model: Codable>: Serializer {
     /// You can customise the `CodableSerializer` by passing another `JSONDecoder` is needed.
     ///
     /// - parameter decoder: The decoder what will be used to convert the json.
-    init(decoder: JSONDecoder = JSONDecoder()) {
+    public init(decoder: JSONDecoder = JSONDecoder()) {
         self.decoder = decoder
     }
     
@@ -43,7 +43,7 @@ public struct CodableSerializer<Model: Codable>: Serializer {
     
     // MARK: - Serialize
     
-    public func serialize(data: Data?, error: Error?, response: URLResponse?) -> CodableSerializer<Model>.Response {
+    public func serialize(data: Data?, error: Error?, response: HTTPURLResponse?) -> CodableSerializer<Model>.Response {
         // When an error occurs we return this error.
         if let error = error { return .failure(error) }
         

--- a/Sources/Serializer/Serializer.swift
+++ b/Sources/Serializer/Serializer.swift
@@ -15,8 +15,8 @@ public protocol Serializer {
     ///
     /// - parameter data: The body'sdata returned by the response.
     /// - parameter error: The error given by the request.
-    /// - parameter response: The url response for more customization.
+    /// - parameter response: The http url response for more customization.
     ///
     /// - returns: A generic response defined by the implementation class.
-    func serialize(data: Data?, error: Error?, response: URLResponse?) -> Response
+    func serialize(data: Data?, error: Error?, response: HTTPURLResponse?) -> Response
 }

--- a/Sources/Service/NetworkService.swift
+++ b/Sources/Service/NetworkService.swift
@@ -23,12 +23,13 @@ class NetworkService {
     
     func execute<S: Serializer>(_ urlRequest: URLRequest,
                                 with serializer: S,
-                                completion: @escaping (_ response: S.Response) -> Void) {
+                                completion: @escaping (_ response: S.Response) -> Void) -> URLSessionDataTask {
         let session = URLSession.shared
         let task = session.dataTask(with: urlRequest) { data, urlResponse, error in
-            let response = serializer.serialize(data: data, error: error, response: urlResponse)
+            let response = serializer.serialize(data: data, error: error, response: urlResponse as? HTTPURLResponse)
             completion(response)
         }
         task.resume()
+        return task
     }
 }

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -6,7 +6,7 @@
 //
 
 /// This it the main executor of requests.
-public class Service {
+open class Service {
     
     // MARK: - Internal
     
@@ -18,7 +18,7 @@ public class Service {
     /// Initialize the Service layer.
     ///
     /// - parameter configuration: Configure the service layer through this instance.
-    init(configuration: Configuration) {
+    public init(configuration: Configuration) {
         self.configuration = configuration
         self.networkService = NetworkService(configuration: configuration)
     }

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -38,16 +38,20 @@ open class Service {
     /// - parameter request: The request to execute.
     /// - parameter serializer: The result of the request will go through serialization.
     /// - paremeter completion: The block that is triggered on completion.
+    ///
+    /// - returns: The executed data task.
+    @discardableResult
     public func execute<S: Serializer>(_ request: Request,
                                        with serializer: S,
-                                       completion: @escaping (_ response: S.Response) -> Void) {
+                                       completion: @escaping (_ response: S.Response) -> Void) -> URLSessionDataTask? {
         do {
             // Try to generate a url request with the given `Request`.
             let urlRequest = try request.makeURLRequest(with: configuration)
-            networkService.execute(urlRequest, with: serializer, completion: completion)
+            return networkService.execute(urlRequest, with: serializer, completion: completion)
         } catch {
             let response = serializer.serialize(data: nil, error: error, response: nil)
             completion(response)
+            return nil
         }
     }
 }


### PR DESCRIPTION
What happend?

* Make some initialisers `public`, thanks @AdamsDevelopment for noticing.
* Make the `Service` `open`.
* Make the base url in the configuration optional.
* Return a `URLSessionDataTask` when executing a request, this request can be cancelled.
* Pass a `HTTPURLResponse` to the serializer.