### PR TITLE
Add a logger

### DIFF
--- a/Example/Cara.xcodeproj/project.pbxproj
+++ b/Example/Cara.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		9D21FEF121D8EE98006EF131 /* PublicKeyPinningServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FEF021D8EE98006EF131 /* PublicKeyPinningServiceSpec.swift */; };
 		9D21FEF321D8F02F006EF131 /* SecTrust+Apple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FEF221D8F02F006EF131 /* SecTrust+Apple.swift */; };
 		9D21FEF521D8F05C006EF131 /* apple.com.cer in Resources */ = {isa = PBXBuildFile; fileRef = 9D21FEF421D8F05C006EF131 /* apple.com.cer */; };
+		9D21FF0621D97196006EF131 /* NetworkServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FF0521D97196006EF131 /* NetworkServiceSpec.swift */; };
+		9D21FF0821D971C6006EF131 /* MockedPublicKeyPinningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FF0721D971C6006EF131 /* MockedPublicKeyPinningService.swift */; };
 		9D28DFA521D8C562002B538A /* ResponseErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D28DFA421D8C562002B538A /* ResponseErrorSpec.swift */; };
 		9D446A9C21B3EAC100FEA1F7 /* ServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2BB56E21B2D5DC0072DA07 /* ServiceSpec.swift */; };
 		9D60FF2821B402CA0078F791 /* MockedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D60FF2721B402CA0078F791 /* MockedRequest.swift */; };
@@ -19,6 +21,7 @@
 		9D60FF2D21B42A560078F791 /* MockedSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D60FF2C21B42A560078F791 /* MockedSerializer.swift */; };
 		9DAD37C221B439F80042C19C /* CodableSerializerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD37C121B439F80042C19C /* CodableSerializerSpec.swift */; };
 		9DAD37C521B45A900042C19C /* RequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD37C421B45A900042C19C /* RequestSpec.swift */; };
+		9DEA80C321D97275002A56A7 /* MockedLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DEA80C221D97275002A56A7 /* MockedLogger.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +35,8 @@
 		9D21FEF021D8EE98006EF131 /* PublicKeyPinningServiceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKeyPinningServiceSpec.swift; sourceTree = "<group>"; };
 		9D21FEF221D8F02F006EF131 /* SecTrust+Apple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecTrust+Apple.swift"; sourceTree = "<group>"; };
 		9D21FEF421D8F05C006EF131 /* apple.com.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = apple.com.cer; sourceTree = "<group>"; };
+		9D21FF0521D97196006EF131 /* NetworkServiceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceSpec.swift; sourceTree = "<group>"; };
+		9D21FF0721D971C6006EF131 /* MockedPublicKeyPinningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedPublicKeyPinningService.swift; sourceTree = "<group>"; };
 		9D28DFA421D8C562002B538A /* ResponseErrorSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseErrorSpec.swift; sourceTree = "<group>"; };
 		9D2BB56E21B2D5DC0072DA07 /* ServiceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceSpec.swift; sourceTree = "<group>"; };
 		9D60FF2721B402CA0078F791 /* MockedRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedRequest.swift; sourceTree = "<group>"; };
@@ -39,6 +44,7 @@
 		9D60FF2C21B42A560078F791 /* MockedSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedSerializer.swift; sourceTree = "<group>"; };
 		9DAD37C121B439F80042C19C /* CodableSerializerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableSerializerSpec.swift; sourceTree = "<group>"; };
 		9DAD37C421B45A900042C19C /* RequestSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestSpec.swift; sourceTree = "<group>"; };
+		9DEA80C221D97275002A56A7 /* MockedLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedLogger.swift; sourceTree = "<group>"; };
 		D97FA3B1B8D63693AAF21BA5 /* Pods_Application.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Application.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F684B53926905060D617A429 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -124,6 +130,8 @@
 			isa = PBXGroup;
 			children = (
 				9D60FF2921B402E00078F791 /* MockedConfiguration.swift */,
+				9DEA80C221D97275002A56A7 /* MockedLogger.swift */,
+				9D21FF0721D971C6006EF131 /* MockedPublicKeyPinningService.swift */,
 				9D60FF2721B402CA0078F791 /* MockedRequest.swift */,
 				9D60FF2C21B42A560078F791 /* MockedSerializer.swift */,
 			);
@@ -133,6 +141,7 @@
 		9DAD37BD21B439990042C19C /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				9D21FF0521D97196006EF131 /* NetworkServiceSpec.swift */,
 				9D21FEF021D8EE98006EF131 /* PublicKeyPinningServiceSpec.swift */,
 				9D28DFA421D8C562002B538A /* ResponseErrorSpec.swift */,
 				9D2BB56E21B2D5DC0072DA07 /* ServiceSpec.swift */,
@@ -326,13 +335,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D446A9C21B3EAC100FEA1F7 /* ServiceSpec.swift in Sources */,
+				9D21FF0621D97196006EF131 /* NetworkServiceSpec.swift in Sources */,
 				9DAD37C521B45A900042C19C /* RequestSpec.swift in Sources */,
 				9D0E402C21B3FC490088D678 /* CaraQuickConfiguration.swift in Sources */,
 				9D60FF2821B402CA0078F791 /* MockedRequest.swift in Sources */,
+				9D21FF0821D971C6006EF131 /* MockedPublicKeyPinningService.swift in Sources */,
 				9D60FF2A21B402E00078F791 /* MockedConfiguration.swift in Sources */,
 				9D21FEF121D8EE98006EF131 /* PublicKeyPinningServiceSpec.swift in Sources */,
 				9D60FF2D21B42A560078F791 /* MockedSerializer.swift in Sources */,
 				9D21FEF321D8F02F006EF131 /* SecTrust+Apple.swift in Sources */,
+				9DEA80C321D97275002A56A7 /* MockedLogger.swift in Sources */,
 				9D28DFA521D8C562002B538A /* ResponseErrorSpec.swift in Sources */,
 				9DAD37C221B439F80042C19C /* CodableSerializerSpec.swift in Sources */,
 			);

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,610 +7,610 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		000000000EC0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
-		000000000ED0 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000130 /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000EE0 /* Dictionary+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000150 /* Dictionary+Merge.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000EF0 /* URLResponse+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000160 /* URLResponse+Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F00 /* ConsoleLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000180 /* ConsoleLogger.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F10 /* Request+URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001A0 /* Request+URLRequest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F20 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001B0 /* Request.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F30 /* RequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001C0 /* RequestMethod.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F40 /* CodableSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001E0 /* CodableSerializer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F50 /* Serializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001F0 /* Serializer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F60 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000210 /* NetworkService.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F70 /* PublicKeyPinningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000220 /* PublicKeyPinningService.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F80 /* ResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000230 /* ResponseError.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F90 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000240 /* Service.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000FE0 /* Cara-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000FD0 /* Cara-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001020 /* Cara-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001010 /* Cara-dummy.m */; };
-		0000000010C0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
-		0000000010D0 /* AEAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000250 /* AEAD.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000010E0 /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000260 /* AEADChaCha20Poly1305.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000010F0 /* AES.Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000270 /* AES.Cryptors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001100 /* AES.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000280 /* AES.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001110 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000290 /* Array+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001120 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002A0 /* Authenticator.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001130 /* BatchedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002B0 /* BatchedCollection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001140 /* Bit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002C0 /* Bit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001150 /* BlockCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002D0 /* BlockCipher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001160 /* BlockDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002E0 /* BlockDecryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001170 /* BlockEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002F0 /* BlockEncryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001180 /* BlockMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000300 /* BlockMode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001190 /* BlockModeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000310 /* BlockModeOptions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011A0 /* CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000320 /* CBC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011B0 /* CCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000330 /* CCM.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011C0 /* CFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000340 /* CFB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011D0 /* CipherModeWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000350 /* CipherModeWorker.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011E0 /* CTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000360 /* CTR.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011F0 /* ECB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000370 /* ECB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001200 /* GCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000380 /* GCM.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001210 /* OFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000390 /* OFB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001220 /* PCBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003A0 /* PCBC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001230 /* Blowfish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003B0 /* Blowfish.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001240 /* CBCMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003C0 /* CBCMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001250 /* ChaCha20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003D0 /* ChaCha20.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001260 /* Checksum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003E0 /* Checksum.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001270 /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003F0 /* Cipher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001280 /* CMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000400 /* CMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001290 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000410 /* Collection+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012A0 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000420 /* CompactMap.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012B0 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000430 /* Cryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012C0 /* Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000440 /* Cryptors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012D0 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000450 /* Digest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012E0 /* DigestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000460 /* DigestType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012F0 /* AES+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000470 /* AES+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001300 /* Array+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000480 /* Array+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001310 /* Blowfish+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000490 /* Blowfish+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001320 /* ChaCha20+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004A0 /* ChaCha20+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001330 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004B0 /* Data+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001340 /* HMAC+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004C0 /* HMAC+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001350 /* Rabbit+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004D0 /* Rabbit+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001360 /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004E0 /* String+FoundationExtension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001370 /* Utils+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004F0 /* Utils+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001380 /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000500 /* Generics.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001390 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000510 /* HKDF.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013A0 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000520 /* HMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013B0 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000530 /* Int+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013C0 /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000540 /* MD5.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013D0 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000550 /* NoPadding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013E0 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000560 /* Operators.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013F0 /* Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000570 /* Padding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001400 /* PBKDF1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000580 /* PBKDF1.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001410 /* PBKDF2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000590 /* PBKDF2.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001420 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005A0 /* PKCS5.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001430 /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005B0 /* PKCS7.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001440 /* PKCS7Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005C0 /* PKCS7Padding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001450 /* Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005D0 /* Poly1305.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001460 /* Rabbit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005E0 /* Rabbit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001470 /* RandomBytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005F0 /* RandomBytesSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001480 /* SecureBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000600 /* SecureBytes.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001490 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000610 /* SHA1.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014A0 /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000620 /* SHA2.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014B0 /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000630 /* SHA3.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014C0 /* StreamDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000640 /* StreamDecryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014D0 /* StreamEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000650 /* StreamEncryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014E0 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000660 /* String+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014F0 /* UInt128.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000670 /* UInt128.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001500 /* UInt16+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000680 /* UInt16+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001510 /* UInt32+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000690 /* UInt32+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001520 /* UInt64+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006A0 /* UInt64+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001530 /* UInt8+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006B0 /* UInt8+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001540 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006C0 /* Updatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001550 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006D0 /* Utils.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001560 /* ZeroPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006E0 /* ZeroPadding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000015B0 /* CryptoSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0000000015A0 /* CryptoSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0000000015F0 /* CryptoSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000000015E0 /* CryptoSwift-dummy.m */; };
-		000000001690 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
-		0000000016A0 /* Mockingjay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000710 /* Mockingjay.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000016B0 /* MockingjayProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000720 /* MockingjayProtocol.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000016C0 /* Builders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000730 /* Builders.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000016D0 /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000740 /* Matchers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000016E0 /* NSURLSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000750 /* NSURLSessionConfiguration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000016F0 /* MockingjayURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000760 /* MockingjayURLSessionConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001700 /* Mockingjay.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000700 /* Mockingjay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001710 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000780 /* XCTest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001760 /* Mockingjay-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001750 /* Mockingjay-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0000000017A0 /* Mockingjay-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001790 /* Mockingjay-dummy.m */; };
-		000000001840 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
-		000000001850 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000790 /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001860 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007A0 /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001870 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007B0 /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001880 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007C0 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001890 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007D0 /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018A0 /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007E0 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018B0 /* NMBObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007F0 /* NMBObjCMatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018C0 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000800 /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018D0 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000810 /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018E0 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000820 /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018F0 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000830 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001900 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000840 /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001910 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000850 /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001920 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000860 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001930 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000870 /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001940 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000880 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001950 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000890 /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001960 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008A0 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001970 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008B0 /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001980 /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008C0 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001990 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008D0 /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019A0 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008E0 /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019B0 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008F0 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019C0 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000900 /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019D0 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000910 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019E0 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000920 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019F0 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000930 /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A00 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000940 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A10 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000950 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A20 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000960 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A30 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000970 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A40 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000980 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A50 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000990 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A60 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009A0 /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A70 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009B0 /* MatcherFunc.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A80 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009C0 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A90 /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009D0 /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AA0 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009E0 /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AB0 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009F0 /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AC0 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A00 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AD0 /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A10 /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AE0 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A20 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AF0 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A30 /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B00 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A40 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B10 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A50 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B20 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A70 /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B30 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A80 /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B40 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A90 /* Functional.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B50 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AA0 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B60 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AB0 /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B70 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AD0 /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B80 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AF0 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B90 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B10 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BA0 /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B20 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BB0 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B30 /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BC0 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B40 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BD0 /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B60 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BE0 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B80 /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BF0 /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BA0 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001C00 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BB0 /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001C10 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BC0 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001C20 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000A60 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C30 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000AC0 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C40 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000AE0 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C50 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B00 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C60 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B50 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C70 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B70 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C80 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B90 /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C90 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000BD0 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001CE0 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001CD0 /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001D20 /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001D10 /* Nimble-dummy.m */; };
-		000000001DC0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
-		000000001DD0 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BE0 /* Behavior.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001DE0 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BF0 /* Callsite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001DF0 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C00 /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E00 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C10 /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E10 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C20 /* World+DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E20 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C30 /* ErrorUtility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E30 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C40 /* Example.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E40 /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C50 /* ExampleGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E50 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C60 /* ExampleMetadata.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E60 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C70 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E70 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C80 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E80 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C90 /* ExampleHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E90 /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CA0 /* HooksPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EA0 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CB0 /* SuiteHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EB0 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CC0 /* NSBundle+CurrentTestBundle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EC0 /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CD0 /* NSString+C99ExtendedIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001ED0 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CE0 /* QuickSelectedTestSuiteBuilder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EE0 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CF0 /* QuickTestSuite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EF0 /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D00 /* URL+FileName.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F00 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D10 /* World.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F10 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D30 /* QuickConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F20 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D50 /* QCKDSL.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F30 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D80 /* QuickSpec.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F40 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D90 /* XCTestSuite+QuickTestSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F50 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000DB0 /* QuickSpecBase.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F60 /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D20 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001F70 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D40 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001F80 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D60 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001F90 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D70 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001FA0 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000DA0 /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		000000001FF0 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001FE0 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000002030 /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000002020 /* Quick-dummy.m */; };
-		0000000020D0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
-		0000000020E0 /* URITemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000DC0 /* URITemplate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000002130 /* URITemplate-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000002120 /* URITemplate-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000002170 /* URITemplate-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000002160 /* URITemplate-dummy.m */; };
-		000000002210 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
-		000000002280 /* Pods-Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000002270 /* Pods-Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0000000022E0 /* Pods-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000000022D0 /* Pods-Tests-dummy.m */; };
-		000000002300 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000022F0 /* XCTest.framework */; };
-		000000002310 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000022F0 /* XCTest.framework */; };
-		000000002370 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000002360 /* CryptoSwift.framework */; };
-		0000000023F0 /* URITemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000023E0 /* URITemplate.framework */; };
-		9D21FF0021D92A4B006EF131 /* OSLog+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FEFF21D92A4B006EF131 /* OSLog+Request.swift */; };
-		9D21FF0221D92A5F006EF131 /* Configuration+Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FF0121D92A5F006EF131 /* Configuration+Logger.swift */; };
-		9D21FF0421D92A70006EF131 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FF0321D92A70006EF131 /* Logger.swift */; };
+		000000000EF0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EE0 /* Foundation.framework */; };
+		000000000F00 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000130 /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F10 /* Dictionary+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000150 /* Dictionary+Merge.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F20 /* URLResponse+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000160 /* URLResponse+Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F30 /* Configuration+Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000180 /* Configuration+Logger.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F40 /* ConsoleLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000190 /* ConsoleLogger.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F50 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001A0 /* Logger.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F60 /* OSLog+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001B0 /* OSLog+Request.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F70 /* Request+URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001D0 /* Request+URLRequest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F80 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001E0 /* Request.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F90 /* RequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001F0 /* RequestMethod.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000FA0 /* CodableSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000210 /* CodableSerializer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000FB0 /* Serializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000220 /* Serializer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000FC0 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000240 /* NetworkService.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000FD0 /* PublicKeyPinningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000250 /* PublicKeyPinningService.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000FE0 /* ResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000260 /* ResponseError.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000FF0 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000270 /* Service.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001040 /* Cara-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001030 /* Cara-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001080 /* Cara-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001070 /* Cara-dummy.m */; };
+		000000001120 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EE0 /* Foundation.framework */; };
+		000000001130 /* AEAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000280 /* AEAD.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001140 /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000290 /* AEADChaCha20Poly1305.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001150 /* AES.Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002A0 /* AES.Cryptors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001160 /* AES.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002B0 /* AES.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001170 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002C0 /* Array+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001180 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002D0 /* Authenticator.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001190 /* BatchedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002E0 /* BatchedCollection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011A0 /* Bit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002F0 /* Bit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011B0 /* BlockCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000300 /* BlockCipher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011C0 /* BlockDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000310 /* BlockDecryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011D0 /* BlockEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000320 /* BlockEncryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011E0 /* BlockMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000330 /* BlockMode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011F0 /* BlockModeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000340 /* BlockModeOptions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001200 /* CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000350 /* CBC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001210 /* CCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000360 /* CCM.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001220 /* CFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000370 /* CFB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001230 /* CipherModeWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000380 /* CipherModeWorker.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001240 /* CTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000390 /* CTR.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001250 /* ECB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003A0 /* ECB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001260 /* GCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003B0 /* GCM.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001270 /* OFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003C0 /* OFB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001280 /* PCBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003D0 /* PCBC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001290 /* Blowfish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003E0 /* Blowfish.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012A0 /* CBCMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003F0 /* CBCMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012B0 /* ChaCha20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000400 /* ChaCha20.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012C0 /* Checksum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000410 /* Checksum.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012D0 /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000420 /* Cipher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012E0 /* CMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000430 /* CMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012F0 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000440 /* Collection+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001300 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000450 /* CompactMap.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001310 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000460 /* Cryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001320 /* Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000470 /* Cryptors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001330 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000480 /* Digest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001340 /* DigestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000490 /* DigestType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001350 /* AES+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004A0 /* AES+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001360 /* Array+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004B0 /* Array+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001370 /* Blowfish+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004C0 /* Blowfish+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001380 /* ChaCha20+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004D0 /* ChaCha20+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001390 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004E0 /* Data+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013A0 /* HMAC+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004F0 /* HMAC+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013B0 /* Rabbit+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000500 /* Rabbit+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013C0 /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000510 /* String+FoundationExtension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013D0 /* Utils+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000520 /* Utils+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013E0 /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000530 /* Generics.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013F0 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000540 /* HKDF.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001400 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000550 /* HMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001410 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000560 /* Int+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001420 /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000570 /* MD5.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001430 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000580 /* NoPadding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001440 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000590 /* Operators.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001450 /* Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005A0 /* Padding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001460 /* PBKDF1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005B0 /* PBKDF1.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001470 /* PBKDF2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005C0 /* PBKDF2.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001480 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005D0 /* PKCS5.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001490 /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005E0 /* PKCS7.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014A0 /* PKCS7Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005F0 /* PKCS7Padding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014B0 /* Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000600 /* Poly1305.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014C0 /* Rabbit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000610 /* Rabbit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014D0 /* RandomBytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000620 /* RandomBytesSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014E0 /* SecureBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000630 /* SecureBytes.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014F0 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000640 /* SHA1.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001500 /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000650 /* SHA2.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001510 /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000660 /* SHA3.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001520 /* StreamDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000670 /* StreamDecryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001530 /* StreamEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000680 /* StreamEncryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001540 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000690 /* String+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001550 /* UInt128.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006A0 /* UInt128.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001560 /* UInt16+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006B0 /* UInt16+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001570 /* UInt32+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006C0 /* UInt32+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001580 /* UInt64+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006D0 /* UInt64+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001590 /* UInt8+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006E0 /* UInt8+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000015A0 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006F0 /* Updatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000015B0 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000700 /* Utils.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000015C0 /* ZeroPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000710 /* ZeroPadding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001610 /* CryptoSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001600 /* CryptoSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001650 /* CryptoSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001640 /* CryptoSwift-dummy.m */; };
+		0000000016F0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EE0 /* Foundation.framework */; };
+		000000001700 /* Mockingjay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000740 /* Mockingjay.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001710 /* MockingjayProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000750 /* MockingjayProtocol.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001720 /* Builders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000760 /* Builders.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001730 /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000770 /* Matchers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001740 /* NSURLSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000780 /* NSURLSessionConfiguration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001750 /* MockingjayURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000790 /* MockingjayURLSessionConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001760 /* Mockingjay.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000730 /* Mockingjay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001770 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007B0 /* XCTest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000017C0 /* Mockingjay-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0000000017B0 /* Mockingjay-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001800 /* Mockingjay-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000000017F0 /* Mockingjay-dummy.m */; };
+		0000000018A0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EE0 /* Foundation.framework */; };
+		0000000018B0 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007C0 /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018C0 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007D0 /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018D0 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007E0 /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018E0 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007F0 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018F0 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000800 /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001900 /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000810 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001910 /* NMBObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000820 /* NMBObjCMatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001920 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000830 /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001930 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000840 /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001940 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000850 /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001950 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000860 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001960 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000870 /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001970 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000880 /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001980 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000890 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001990 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008A0 /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019A0 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008B0 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019B0 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008C0 /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019C0 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008D0 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019D0 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008E0 /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019E0 /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008F0 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019F0 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000900 /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A00 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000910 /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A10 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000920 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A20 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000930 /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A30 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000940 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A40 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000950 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A50 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000960 /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A60 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000970 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A70 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000980 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A80 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000990 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A90 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009A0 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AA0 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009B0 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AB0 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009C0 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AC0 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009D0 /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AD0 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009E0 /* MatcherFunc.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AE0 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009F0 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AF0 /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A00 /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B00 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A10 /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B10 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A20 /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B20 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A30 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B30 /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A40 /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B40 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A50 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B50 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A60 /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B60 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A70 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B70 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A80 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B80 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AA0 /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B90 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AB0 /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BA0 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AC0 /* Functional.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BB0 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AD0 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BC0 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AE0 /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BD0 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B00 /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BE0 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B20 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BF0 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B40 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C00 /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B50 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C10 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B60 /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C20 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B70 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C30 /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B90 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C40 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BB0 /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C50 /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BD0 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C60 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BE0 /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C70 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BF0 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C80 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000A90 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001C90 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000AF0 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001CA0 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B10 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001CB0 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B30 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001CC0 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B80 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001CD0 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000BA0 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001CE0 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000BC0 /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001CF0 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000C00 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001D40 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001D30 /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001D80 /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001D70 /* Nimble-dummy.m */; };
+		000000001E20 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EE0 /* Foundation.framework */; };
+		000000001E30 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C10 /* Behavior.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E40 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C20 /* Callsite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E50 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C30 /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E60 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C40 /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E70 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C50 /* World+DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E80 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C60 /* ErrorUtility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E90 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C70 /* Example.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EA0 /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C80 /* ExampleGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EB0 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C90 /* ExampleMetadata.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EC0 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CA0 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001ED0 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CB0 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EE0 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CC0 /* ExampleHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EF0 /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CD0 /* HooksPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F00 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CE0 /* SuiteHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F10 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CF0 /* NSBundle+CurrentTestBundle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F20 /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D00 /* NSString+C99ExtendedIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F30 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D10 /* QuickSelectedTestSuiteBuilder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F40 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D20 /* QuickTestSuite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F50 /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D30 /* URL+FileName.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F60 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D40 /* World.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F70 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D60 /* QuickConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F80 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D80 /* QCKDSL.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F90 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000DB0 /* QuickSpec.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001FA0 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000DC0 /* XCTestSuite+QuickTestSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001FB0 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000DE0 /* QuickSpecBase.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001FC0 /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D50 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001FD0 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D70 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001FE0 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D90 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001FF0 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000DA0 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000002000 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000DD0 /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		000000002050 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000002040 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000002090 /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000002080 /* Quick-dummy.m */; };
+		000000002130 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EE0 /* Foundation.framework */; };
+		000000002140 /* URITemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000DF0 /* URITemplate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000002190 /* URITemplate-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000002180 /* URITemplate-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0000000021D0 /* URITemplate-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000000021C0 /* URITemplate-dummy.m */; };
+		000000002270 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EE0 /* Foundation.framework */; };
+		0000000022E0 /* Pods-Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0000000022D0 /* Pods-Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000002340 /* Pods-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000002330 /* Pods-Tests-dummy.m */; };
+		000000002360 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000002350 /* XCTest.framework */; };
+		000000002370 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000002350 /* XCTest.framework */; };
+		0000000023D0 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000023C0 /* CryptoSwift.framework */; };
+		000000002450 /* URITemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000002440 /* URITemplate.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		000000002320 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 000000000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 000000000E10;
-			remoteInfo = Cara;
-		};
-		000000002340 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 000000000000 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 000000001030;
-			remoteInfo = CryptoSwift;
-		};
 		000000002380 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000001030;
-			remoteInfo = CryptoSwift;
+			remoteGlobalIDString = 000000000E40;
+			remoteInfo = Cara;
 		};
 		0000000023A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000001600;
-			remoteInfo = Mockingjay;
+			remoteGlobalIDString = 000000001090;
+			remoteInfo = CryptoSwift;
 		};
-		0000000023C0 /* PBXContainerItemProxy */ = {
+		0000000023E0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000002040;
-			remoteInfo = URITemplate;
+			remoteGlobalIDString = 000000001090;
+			remoteInfo = CryptoSwift;
 		};
 		000000002400 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 0000000017B0;
-			remoteInfo = Nimble;
+			remoteGlobalIDString = 000000001660;
+			remoteInfo = Mockingjay;
 		};
 		000000002420 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000001D30;
-			remoteInfo = Quick;
+			remoteGlobalIDString = 0000000020A0;
+			remoteInfo = URITemplate;
 		};
-		000000002440 /* PBXContainerItemProxy */ = {
+		000000002460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000002040;
+			remoteGlobalIDString = 000000001810;
+			remoteInfo = Nimble;
+		};
+		000000002480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 000000000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 000000001D90;
+			remoteInfo = Quick;
+		};
+		0000000024A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 000000000000 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0000000020A0;
 			remoteInfo = URITemplate;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		000000000110 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		000000000110 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		000000000130 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		000000000150 /* Dictionary+Merge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Dictionary+Merge.swift"; sourceTree = "<group>"; };
 		000000000160 /* URLResponse+Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "URLResponse+Error.swift"; sourceTree = "<group>"; };
-		000000000180 /* ConsoleLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsoleLogger.swift; sourceTree = "<group>"; };
-		0000000001A0 /* Request+URLRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+URLRequest.swift"; sourceTree = "<group>"; };
-		0000000001B0 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
-		0000000001C0 /* RequestMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RequestMethod.swift; sourceTree = "<group>"; };
-		0000000001E0 /* CodableSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodableSerializer.swift; sourceTree = "<group>"; };
-		0000000001F0 /* Serializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Serializer.swift; sourceTree = "<group>"; };
-		000000000210 /* NetworkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
-		000000000220 /* PublicKeyPinningService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PublicKeyPinningService.swift; sourceTree = "<group>"; };
-		000000000230 /* ResponseError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResponseError.swift; sourceTree = "<group>"; };
-		000000000240 /* Service.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
-		000000000250 /* AEAD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEAD.swift; path = Sources/CryptoSwift/AEAD/AEAD.swift; sourceTree = "<group>"; };
-		000000000260 /* AEADChaCha20Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEADChaCha20Poly1305.swift; path = Sources/CryptoSwift/AEAD/AEADChaCha20Poly1305.swift; sourceTree = "<group>"; };
-		000000000270 /* AES.Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.Cryptors.swift; path = Sources/CryptoSwift/AES.Cryptors.swift; sourceTree = "<group>"; };
-		000000000280 /* AES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.swift; path = Sources/CryptoSwift/AES.swift; sourceTree = "<group>"; };
-		000000000290 /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "Sources/CryptoSwift/Array+Extension.swift"; sourceTree = "<group>"; };
-		0000000002A0 /* Authenticator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authenticator.swift; path = Sources/CryptoSwift/Authenticator.swift; sourceTree = "<group>"; };
-		0000000002B0 /* BatchedCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BatchedCollection.swift; path = Sources/CryptoSwift/BatchedCollection.swift; sourceTree = "<group>"; };
-		0000000002C0 /* Bit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bit.swift; path = Sources/CryptoSwift/Bit.swift; sourceTree = "<group>"; };
-		0000000002D0 /* BlockCipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockCipher.swift; path = Sources/CryptoSwift/BlockCipher.swift; sourceTree = "<group>"; };
-		0000000002E0 /* BlockDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockDecryptor.swift; path = Sources/CryptoSwift/BlockDecryptor.swift; sourceTree = "<group>"; };
-		0000000002F0 /* BlockEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockEncryptor.swift; path = Sources/CryptoSwift/BlockEncryptor.swift; sourceTree = "<group>"; };
-		000000000300 /* BlockMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockMode.swift; path = Sources/CryptoSwift/BlockMode/BlockMode.swift; sourceTree = "<group>"; };
-		000000000310 /* BlockModeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockModeOptions.swift; path = Sources/CryptoSwift/BlockMode/BlockModeOptions.swift; sourceTree = "<group>"; };
-		000000000320 /* CBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBC.swift; path = Sources/CryptoSwift/BlockMode/CBC.swift; sourceTree = "<group>"; };
-		000000000330 /* CCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CCM.swift; path = Sources/CryptoSwift/BlockMode/CCM.swift; sourceTree = "<group>"; };
-		000000000340 /* CFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CFB.swift; path = Sources/CryptoSwift/BlockMode/CFB.swift; sourceTree = "<group>"; };
-		000000000350 /* CipherModeWorker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CipherModeWorker.swift; path = Sources/CryptoSwift/BlockMode/CipherModeWorker.swift; sourceTree = "<group>"; };
-		000000000360 /* CTR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CTR.swift; path = Sources/CryptoSwift/BlockMode/CTR.swift; sourceTree = "<group>"; };
-		000000000370 /* ECB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ECB.swift; path = Sources/CryptoSwift/BlockMode/ECB.swift; sourceTree = "<group>"; };
-		000000000380 /* GCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCM.swift; path = Sources/CryptoSwift/BlockMode/GCM.swift; sourceTree = "<group>"; };
-		000000000390 /* OFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OFB.swift; path = Sources/CryptoSwift/BlockMode/OFB.swift; sourceTree = "<group>"; };
-		0000000003A0 /* PCBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PCBC.swift; path = Sources/CryptoSwift/BlockMode/PCBC.swift; sourceTree = "<group>"; };
-		0000000003B0 /* Blowfish.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Blowfish.swift; path = Sources/CryptoSwift/Blowfish.swift; sourceTree = "<group>"; };
-		0000000003C0 /* CBCMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBCMAC.swift; path = Sources/CryptoSwift/CBCMAC.swift; sourceTree = "<group>"; };
-		0000000003D0 /* ChaCha20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChaCha20.swift; path = Sources/CryptoSwift/ChaCha20.swift; sourceTree = "<group>"; };
-		0000000003E0 /* Checksum.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Checksum.swift; path = Sources/CryptoSwift/Checksum.swift; sourceTree = "<group>"; };
-		0000000003F0 /* Cipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cipher.swift; path = Sources/CryptoSwift/Cipher.swift; sourceTree = "<group>"; };
-		000000000400 /* CMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CMAC.swift; path = Sources/CryptoSwift/CMAC.swift; sourceTree = "<group>"; };
-		000000000410 /* Collection+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Collection+Extension.swift"; path = "Sources/CryptoSwift/Collection+Extension.swift"; sourceTree = "<group>"; };
-		000000000420 /* CompactMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompactMap.swift; path = Sources/CryptoSwift/CompactMap.swift; sourceTree = "<group>"; };
-		000000000430 /* Cryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptor.swift; path = Sources/CryptoSwift/Cryptor.swift; sourceTree = "<group>"; };
-		000000000440 /* Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptors.swift; path = Sources/CryptoSwift/Cryptors.swift; sourceTree = "<group>"; };
-		000000000450 /* Digest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Digest.swift; path = Sources/CryptoSwift/Digest.swift; sourceTree = "<group>"; };
-		000000000460 /* DigestType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DigestType.swift; path = Sources/CryptoSwift/DigestType.swift; sourceTree = "<group>"; };
-		000000000470 /* AES+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AES+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/AES+Foundation.swift"; sourceTree = "<group>"; };
-		000000000480 /* Array+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Array+Foundation.swift"; sourceTree = "<group>"; };
-		000000000490 /* Blowfish+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Blowfish+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Blowfish+Foundation.swift"; sourceTree = "<group>"; };
-		0000000004A0 /* ChaCha20+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ChaCha20+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/ChaCha20+Foundation.swift"; sourceTree = "<group>"; };
-		0000000004B0 /* Data+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extension.swift"; path = "Sources/CryptoSwift/Foundation/Data+Extension.swift"; sourceTree = "<group>"; };
-		0000000004C0 /* HMAC+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HMAC+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/HMAC+Foundation.swift"; sourceTree = "<group>"; };
-		0000000004D0 /* Rabbit+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Rabbit+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Rabbit+Foundation.swift"; sourceTree = "<group>"; };
-		0000000004E0 /* String+FoundationExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+FoundationExtension.swift"; path = "Sources/CryptoSwift/Foundation/String+FoundationExtension.swift"; sourceTree = "<group>"; };
-		0000000004F0 /* Utils+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Utils+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Utils+Foundation.swift"; sourceTree = "<group>"; };
-		000000000500 /* Generics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generics.swift; path = Sources/CryptoSwift/Generics.swift; sourceTree = "<group>"; };
-		000000000510 /* HKDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HKDF.swift; path = Sources/CryptoSwift/HKDF.swift; sourceTree = "<group>"; };
-		000000000520 /* HMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HMAC.swift; path = Sources/CryptoSwift/HMAC.swift; sourceTree = "<group>"; };
-		000000000530 /* Int+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Int+Extension.swift"; path = "Sources/CryptoSwift/Int+Extension.swift"; sourceTree = "<group>"; };
-		000000000540 /* MD5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MD5.swift; path = Sources/CryptoSwift/MD5.swift; sourceTree = "<group>"; };
-		000000000550 /* NoPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoPadding.swift; path = Sources/CryptoSwift/NoPadding.swift; sourceTree = "<group>"; };
-		000000000560 /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Sources/CryptoSwift/Operators.swift; sourceTree = "<group>"; };
-		000000000570 /* Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Padding.swift; path = Sources/CryptoSwift/Padding.swift; sourceTree = "<group>"; };
-		000000000580 /* PBKDF1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF1.swift; path = Sources/CryptoSwift/PKCS/PBKDF1.swift; sourceTree = "<group>"; };
-		000000000590 /* PBKDF2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF2.swift; path = Sources/CryptoSwift/PKCS/PBKDF2.swift; sourceTree = "<group>"; };
-		0000000005A0 /* PKCS5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS5.swift; path = Sources/CryptoSwift/PKCS/PKCS5.swift; sourceTree = "<group>"; };
-		0000000005B0 /* PKCS7.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7.swift; path = Sources/CryptoSwift/PKCS/PKCS7.swift; sourceTree = "<group>"; };
-		0000000005C0 /* PKCS7Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7Padding.swift; path = Sources/CryptoSwift/PKCS/PKCS7Padding.swift; sourceTree = "<group>"; };
-		0000000005D0 /* Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Poly1305.swift; path = Sources/CryptoSwift/Poly1305.swift; sourceTree = "<group>"; };
-		0000000005E0 /* Rabbit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rabbit.swift; path = Sources/CryptoSwift/Rabbit.swift; sourceTree = "<group>"; };
-		0000000005F0 /* RandomBytesSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RandomBytesSequence.swift; path = Sources/CryptoSwift/RandomBytesSequence.swift; sourceTree = "<group>"; };
-		000000000600 /* SecureBytes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecureBytes.swift; path = Sources/CryptoSwift/SecureBytes.swift; sourceTree = "<group>"; };
-		000000000610 /* SHA1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA1.swift; path = Sources/CryptoSwift/SHA1.swift; sourceTree = "<group>"; };
-		000000000620 /* SHA2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA2.swift; path = Sources/CryptoSwift/SHA2.swift; sourceTree = "<group>"; };
-		000000000630 /* SHA3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA3.swift; path = Sources/CryptoSwift/SHA3.swift; sourceTree = "<group>"; };
-		000000000640 /* StreamDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamDecryptor.swift; path = Sources/CryptoSwift/StreamDecryptor.swift; sourceTree = "<group>"; };
-		000000000650 /* StreamEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamEncryptor.swift; path = Sources/CryptoSwift/StreamEncryptor.swift; sourceTree = "<group>"; };
-		000000000660 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "Sources/CryptoSwift/String+Extension.swift"; sourceTree = "<group>"; };
-		000000000670 /* UInt128.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UInt128.swift; path = Sources/CryptoSwift/UInt128.swift; sourceTree = "<group>"; };
-		000000000680 /* UInt16+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt16+Extension.swift"; path = "Sources/CryptoSwift/UInt16+Extension.swift"; sourceTree = "<group>"; };
-		000000000690 /* UInt32+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt32+Extension.swift"; path = "Sources/CryptoSwift/UInt32+Extension.swift"; sourceTree = "<group>"; };
-		0000000006A0 /* UInt64+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt64+Extension.swift"; path = "Sources/CryptoSwift/UInt64+Extension.swift"; sourceTree = "<group>"; };
-		0000000006B0 /* UInt8+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt8+Extension.swift"; path = "Sources/CryptoSwift/UInt8+Extension.swift"; sourceTree = "<group>"; };
-		0000000006C0 /* Updatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Updatable.swift; path = Sources/CryptoSwift/Updatable.swift; sourceTree = "<group>"; };
-		0000000006D0 /* Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = Sources/CryptoSwift/Utils.swift; sourceTree = "<group>"; };
-		0000000006E0 /* ZeroPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ZeroPadding.swift; path = Sources/CryptoSwift/ZeroPadding.swift; sourceTree = "<group>"; };
-		000000000700 /* Mockingjay.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Mockingjay.h; path = Sources/Mockingjay/Mockingjay.h; sourceTree = "<group>"; };
-		000000000710 /* Mockingjay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Mockingjay.swift; path = Sources/Mockingjay/Mockingjay.swift; sourceTree = "<group>"; };
-		000000000720 /* MockingjayProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockingjayProtocol.swift; path = Sources/Mockingjay/MockingjayProtocol.swift; sourceTree = "<group>"; };
-		000000000730 /* Builders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Builders.swift; path = Sources/Mockingjay/Builders.swift; sourceTree = "<group>"; };
-		000000000740 /* Matchers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Matchers.swift; path = Sources/Mockingjay/Matchers.swift; sourceTree = "<group>"; };
-		000000000750 /* NSURLSessionConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSURLSessionConfiguration.swift; path = Sources/Mockingjay/NSURLSessionConfiguration.swift; sourceTree = "<group>"; };
-		000000000760 /* MockingjayURLSessionConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MockingjayURLSessionConfiguration.m; path = Sources/Mockingjay/MockingjayURLSessionConfiguration.m; sourceTree = "<group>"; };
-		000000000780 /* XCTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCTest.swift; path = Sources/Mockingjay/XCTest.swift; sourceTree = "<group>"; };
-		000000000790 /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
-		0000000007A0 /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
-		0000000007B0 /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
-		0000000007C0 /* NimbleEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleEnvironment.swift; path = Sources/Nimble/Adapters/NimbleEnvironment.swift; sourceTree = "<group>"; };
-		0000000007D0 /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
-		0000000007E0 /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
-		0000000007F0 /* NMBObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBObjCMatcher.swift; path = Sources/Nimble/Adapters/NMBObjCMatcher.swift; sourceTree = "<group>"; };
-		000000000800 /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
-		000000000810 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
-		000000000820 /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
-		000000000830 /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
-		000000000840 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
-		000000000850 /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
-		000000000860 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
-		000000000870 /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Matchers/Async.swift; sourceTree = "<group>"; };
-		000000000880 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
-		000000000890 /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
-		0000000008A0 /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
-		0000000008B0 /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
-		0000000008C0 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
-		0000000008D0 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
-		0000000008E0 /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
-		0000000008F0 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
-		000000000900 /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
-		000000000910 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
-		000000000920 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
-		000000000930 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
-		000000000940 /* BeVoid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeVoid.swift; path = Sources/Nimble/Matchers/BeVoid.swift; sourceTree = "<group>"; };
-		000000000950 /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
-		000000000960 /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
-		000000000970 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
-		000000000980 /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Sources/Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
-		000000000990 /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
-		0000000009A0 /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
-		0000000009B0 /* MatcherFunc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherFunc.swift; path = Sources/Nimble/Matchers/MatcherFunc.swift; sourceTree = "<group>"; };
-		0000000009C0 /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
-		0000000009D0 /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
-		0000000009E0 /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
-		0000000009F0 /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
-		000000000A00 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
-		000000000A10 /* SatisfyAllOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAllOf.swift; path = Sources/Nimble/Matchers/SatisfyAllOf.swift; sourceTree = "<group>"; };
-		000000000A20 /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
-		000000000A30 /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
-		000000000A40 /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
-		000000000A50 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
-		000000000A60 /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
-		000000000A70 /* Await.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Await.swift; path = Sources/Nimble/Utils/Await.swift; sourceTree = "<group>"; };
-		000000000A80 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
-		000000000A90 /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Sources/Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
-		000000000AA0 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
-		000000000AB0 /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
-		000000000AC0 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
-		000000000AD0 /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
-		000000000AE0 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
-		000000000AF0 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
-		000000000B00 /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
-		000000000B10 /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
-		000000000B20 /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
-		000000000B30 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
-		000000000B40 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
-		000000000B50 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
-		000000000B60 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
-		000000000B70 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
-		000000000B80 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
-		000000000B90 /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
-		000000000BA0 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
-		000000000BB0 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
-		000000000BC0 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
-		000000000BD0 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Mach/CwlPreconditionTesting.h; sourceTree = "<group>"; };
-		000000000BE0 /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
-		000000000BF0 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
-		000000000C00 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Quick/Configuration/Configuration.swift; sourceTree = "<group>"; };
-		000000000C10 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
-		000000000C20 /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
-		000000000C30 /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
-		000000000C40 /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
-		000000000C50 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
-		000000000C60 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
-		000000000C70 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
-		000000000C80 /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
-		000000000C90 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
-		000000000CA0 /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
-		000000000CB0 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
-		000000000CC0 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
-		000000000CD0 /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
-		000000000CE0 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
-		000000000CF0 /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
-		000000000D00 /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
-		000000000D10 /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Sources/Quick/World.swift; sourceTree = "<group>"; };
-		000000000D20 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
-		000000000D30 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
-		000000000D40 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
-		000000000D50 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Sources/QuickObjectiveC/DSL/QCKDSL.m; sourceTree = "<group>"; };
-		000000000D60 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
-		000000000D70 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
-		000000000D80 /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
-		000000000D90 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
-		000000000DA0 /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
-		000000000DB0 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickSpecBase/QuickSpecBase.m; sourceTree = "<group>"; };
-		000000000DC0 /* URITemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URITemplate.swift; path = Sources/URITemplate.swift; sourceTree = "<group>"; };
-		000000000DE0 /* Cara.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = Cara.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		000000000DF0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
-		000000000E00 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		000000000E50 /* Cara.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cara.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000000EB0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		000000000FB0 /* Cara.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Cara.xcconfig; sourceTree = "<group>"; };
-		000000000FC0 /* Cara.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Cara.modulemap; sourceTree = "<group>"; };
-		000000000FD0 /* Cara-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Cara-umbrella.h"; sourceTree = "<group>"; };
-		000000000FF0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000001000 /* Cara-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Cara-prefix.pch"; sourceTree = "<group>"; };
-		000000001010 /* Cara-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Cara-dummy.m"; sourceTree = "<group>"; };
-		000000001070 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000001580 /* CryptoSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.xcconfig; sourceTree = "<group>"; };
-		000000001590 /* CryptoSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CryptoSwift.modulemap; sourceTree = "<group>"; };
-		0000000015A0 /* CryptoSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-umbrella.h"; sourceTree = "<group>"; };
-		0000000015C0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		0000000015D0 /* CryptoSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-prefix.pch"; sourceTree = "<group>"; };
-		0000000015E0 /* CryptoSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CryptoSwift-dummy.m"; sourceTree = "<group>"; };
-		000000001640 /* Mockingjay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mockingjay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000001730 /* Mockingjay.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Mockingjay.xcconfig; sourceTree = "<group>"; };
-		000000001740 /* Mockingjay.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Mockingjay.modulemap; sourceTree = "<group>"; };
-		000000001750 /* Mockingjay-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Mockingjay-umbrella.h"; sourceTree = "<group>"; };
-		000000001770 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000001780 /* Mockingjay-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Mockingjay-prefix.pch"; sourceTree = "<group>"; };
-		000000001790 /* Mockingjay-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Mockingjay-dummy.m"; sourceTree = "<group>"; };
-		0000000017F0 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000001CB0 /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
-		000000001CC0 /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
-		000000001CD0 /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
-		000000001CF0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000001D00 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
-		000000001D10 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
-		000000001D70 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000001FC0 /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
-		000000001FD0 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
-		000000001FE0 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
-		000000002000 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000002010 /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
-		000000002020 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
-		000000002080 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000002100 /* URITemplate.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = URITemplate.xcconfig; sourceTree = "<group>"; };
-		000000002110 /* URITemplate.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = URITemplate.modulemap; sourceTree = "<group>"; };
-		000000002120 /* URITemplate-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-umbrella.h"; sourceTree = "<group>"; };
-		000000002140 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000002150 /* URITemplate-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-prefix.pch"; sourceTree = "<group>"; };
-		000000002160 /* URITemplate-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "URITemplate-dummy.m"; sourceTree = "<group>"; };
-		0000000021C0 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000002230 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
-		000000002240 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		000000002250 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000002260 /* Pods-Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Tests.modulemap"; sourceTree = "<group>"; };
-		000000002270 /* Pods-Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tests-umbrella.h"; sourceTree = "<group>"; };
-		000000002290 /* Pods-Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-frameworks.sh"; sourceTree = "<group>"; };
-		0000000022A0 /* Pods-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-resources.sh"; sourceTree = "<group>"; };
-		0000000022B0 /* Pods-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		0000000022C0 /* Pods-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		0000000022D0 /* Pods-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tests-dummy.m"; sourceTree = "<group>"; };
-		0000000022F0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		000000002360 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0000000023E0 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9D21FEFF21D92A4B006EF131 /* OSLog+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OSLog+Request.swift"; sourceTree = "<group>"; };
-		9D21FF0121D92A5F006EF131 /* Configuration+Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+Logger.swift"; sourceTree = "<group>"; };
-		9D21FF0321D92A70006EF131 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		000000000180 /* Configuration+Logger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Configuration+Logger.swift"; sourceTree = "<group>"; };
+		000000000190 /* ConsoleLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsoleLogger.swift; sourceTree = "<group>"; };
+		0000000001A0 /* Logger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		0000000001B0 /* OSLog+Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OSLog+Request.swift"; sourceTree = "<group>"; };
+		0000000001D0 /* Request+URLRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+URLRequest.swift"; sourceTree = "<group>"; };
+		0000000001E0 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		0000000001F0 /* RequestMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RequestMethod.swift; sourceTree = "<group>"; };
+		000000000210 /* CodableSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodableSerializer.swift; sourceTree = "<group>"; };
+		000000000220 /* Serializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Serializer.swift; sourceTree = "<group>"; };
+		000000000240 /* NetworkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		000000000250 /* PublicKeyPinningService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PublicKeyPinningService.swift; sourceTree = "<group>"; };
+		000000000260 /* ResponseError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResponseError.swift; sourceTree = "<group>"; };
+		000000000270 /* Service.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
+		000000000280 /* AEAD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEAD.swift; path = Sources/CryptoSwift/AEAD/AEAD.swift; sourceTree = "<group>"; };
+		000000000290 /* AEADChaCha20Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEADChaCha20Poly1305.swift; path = Sources/CryptoSwift/AEAD/AEADChaCha20Poly1305.swift; sourceTree = "<group>"; };
+		0000000002A0 /* AES.Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.Cryptors.swift; path = Sources/CryptoSwift/AES.Cryptors.swift; sourceTree = "<group>"; };
+		0000000002B0 /* AES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.swift; path = Sources/CryptoSwift/AES.swift; sourceTree = "<group>"; };
+		0000000002C0 /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "Sources/CryptoSwift/Array+Extension.swift"; sourceTree = "<group>"; };
+		0000000002D0 /* Authenticator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authenticator.swift; path = Sources/CryptoSwift/Authenticator.swift; sourceTree = "<group>"; };
+		0000000002E0 /* BatchedCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BatchedCollection.swift; path = Sources/CryptoSwift/BatchedCollection.swift; sourceTree = "<group>"; };
+		0000000002F0 /* Bit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bit.swift; path = Sources/CryptoSwift/Bit.swift; sourceTree = "<group>"; };
+		000000000300 /* BlockCipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockCipher.swift; path = Sources/CryptoSwift/BlockCipher.swift; sourceTree = "<group>"; };
+		000000000310 /* BlockDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockDecryptor.swift; path = Sources/CryptoSwift/BlockDecryptor.swift; sourceTree = "<group>"; };
+		000000000320 /* BlockEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockEncryptor.swift; path = Sources/CryptoSwift/BlockEncryptor.swift; sourceTree = "<group>"; };
+		000000000330 /* BlockMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockMode.swift; path = Sources/CryptoSwift/BlockMode/BlockMode.swift; sourceTree = "<group>"; };
+		000000000340 /* BlockModeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockModeOptions.swift; path = Sources/CryptoSwift/BlockMode/BlockModeOptions.swift; sourceTree = "<group>"; };
+		000000000350 /* CBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBC.swift; path = Sources/CryptoSwift/BlockMode/CBC.swift; sourceTree = "<group>"; };
+		000000000360 /* CCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CCM.swift; path = Sources/CryptoSwift/BlockMode/CCM.swift; sourceTree = "<group>"; };
+		000000000370 /* CFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CFB.swift; path = Sources/CryptoSwift/BlockMode/CFB.swift; sourceTree = "<group>"; };
+		000000000380 /* CipherModeWorker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CipherModeWorker.swift; path = Sources/CryptoSwift/BlockMode/CipherModeWorker.swift; sourceTree = "<group>"; };
+		000000000390 /* CTR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CTR.swift; path = Sources/CryptoSwift/BlockMode/CTR.swift; sourceTree = "<group>"; };
+		0000000003A0 /* ECB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ECB.swift; path = Sources/CryptoSwift/BlockMode/ECB.swift; sourceTree = "<group>"; };
+		0000000003B0 /* GCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCM.swift; path = Sources/CryptoSwift/BlockMode/GCM.swift; sourceTree = "<group>"; };
+		0000000003C0 /* OFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OFB.swift; path = Sources/CryptoSwift/BlockMode/OFB.swift; sourceTree = "<group>"; };
+		0000000003D0 /* PCBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PCBC.swift; path = Sources/CryptoSwift/BlockMode/PCBC.swift; sourceTree = "<group>"; };
+		0000000003E0 /* Blowfish.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Blowfish.swift; path = Sources/CryptoSwift/Blowfish.swift; sourceTree = "<group>"; };
+		0000000003F0 /* CBCMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBCMAC.swift; path = Sources/CryptoSwift/CBCMAC.swift; sourceTree = "<group>"; };
+		000000000400 /* ChaCha20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChaCha20.swift; path = Sources/CryptoSwift/ChaCha20.swift; sourceTree = "<group>"; };
+		000000000410 /* Checksum.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Checksum.swift; path = Sources/CryptoSwift/Checksum.swift; sourceTree = "<group>"; };
+		000000000420 /* Cipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cipher.swift; path = Sources/CryptoSwift/Cipher.swift; sourceTree = "<group>"; };
+		000000000430 /* CMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CMAC.swift; path = Sources/CryptoSwift/CMAC.swift; sourceTree = "<group>"; };
+		000000000440 /* Collection+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Collection+Extension.swift"; path = "Sources/CryptoSwift/Collection+Extension.swift"; sourceTree = "<group>"; };
+		000000000450 /* CompactMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompactMap.swift; path = Sources/CryptoSwift/CompactMap.swift; sourceTree = "<group>"; };
+		000000000460 /* Cryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptor.swift; path = Sources/CryptoSwift/Cryptor.swift; sourceTree = "<group>"; };
+		000000000470 /* Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptors.swift; path = Sources/CryptoSwift/Cryptors.swift; sourceTree = "<group>"; };
+		000000000480 /* Digest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Digest.swift; path = Sources/CryptoSwift/Digest.swift; sourceTree = "<group>"; };
+		000000000490 /* DigestType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DigestType.swift; path = Sources/CryptoSwift/DigestType.swift; sourceTree = "<group>"; };
+		0000000004A0 /* AES+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AES+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/AES+Foundation.swift"; sourceTree = "<group>"; };
+		0000000004B0 /* Array+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Array+Foundation.swift"; sourceTree = "<group>"; };
+		0000000004C0 /* Blowfish+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Blowfish+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Blowfish+Foundation.swift"; sourceTree = "<group>"; };
+		0000000004D0 /* ChaCha20+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ChaCha20+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/ChaCha20+Foundation.swift"; sourceTree = "<group>"; };
+		0000000004E0 /* Data+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extension.swift"; path = "Sources/CryptoSwift/Foundation/Data+Extension.swift"; sourceTree = "<group>"; };
+		0000000004F0 /* HMAC+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HMAC+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/HMAC+Foundation.swift"; sourceTree = "<group>"; };
+		000000000500 /* Rabbit+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Rabbit+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Rabbit+Foundation.swift"; sourceTree = "<group>"; };
+		000000000510 /* String+FoundationExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+FoundationExtension.swift"; path = "Sources/CryptoSwift/Foundation/String+FoundationExtension.swift"; sourceTree = "<group>"; };
+		000000000520 /* Utils+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Utils+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Utils+Foundation.swift"; sourceTree = "<group>"; };
+		000000000530 /* Generics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generics.swift; path = Sources/CryptoSwift/Generics.swift; sourceTree = "<group>"; };
+		000000000540 /* HKDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HKDF.swift; path = Sources/CryptoSwift/HKDF.swift; sourceTree = "<group>"; };
+		000000000550 /* HMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HMAC.swift; path = Sources/CryptoSwift/HMAC.swift; sourceTree = "<group>"; };
+		000000000560 /* Int+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Int+Extension.swift"; path = "Sources/CryptoSwift/Int+Extension.swift"; sourceTree = "<group>"; };
+		000000000570 /* MD5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MD5.swift; path = Sources/CryptoSwift/MD5.swift; sourceTree = "<group>"; };
+		000000000580 /* NoPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoPadding.swift; path = Sources/CryptoSwift/NoPadding.swift; sourceTree = "<group>"; };
+		000000000590 /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Sources/CryptoSwift/Operators.swift; sourceTree = "<group>"; };
+		0000000005A0 /* Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Padding.swift; path = Sources/CryptoSwift/Padding.swift; sourceTree = "<group>"; };
+		0000000005B0 /* PBKDF1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF1.swift; path = Sources/CryptoSwift/PKCS/PBKDF1.swift; sourceTree = "<group>"; };
+		0000000005C0 /* PBKDF2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF2.swift; path = Sources/CryptoSwift/PKCS/PBKDF2.swift; sourceTree = "<group>"; };
+		0000000005D0 /* PKCS5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS5.swift; path = Sources/CryptoSwift/PKCS/PKCS5.swift; sourceTree = "<group>"; };
+		0000000005E0 /* PKCS7.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7.swift; path = Sources/CryptoSwift/PKCS/PKCS7.swift; sourceTree = "<group>"; };
+		0000000005F0 /* PKCS7Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7Padding.swift; path = Sources/CryptoSwift/PKCS/PKCS7Padding.swift; sourceTree = "<group>"; };
+		000000000600 /* Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Poly1305.swift; path = Sources/CryptoSwift/Poly1305.swift; sourceTree = "<group>"; };
+		000000000610 /* Rabbit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rabbit.swift; path = Sources/CryptoSwift/Rabbit.swift; sourceTree = "<group>"; };
+		000000000620 /* RandomBytesSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RandomBytesSequence.swift; path = Sources/CryptoSwift/RandomBytesSequence.swift; sourceTree = "<group>"; };
+		000000000630 /* SecureBytes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecureBytes.swift; path = Sources/CryptoSwift/SecureBytes.swift; sourceTree = "<group>"; };
+		000000000640 /* SHA1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA1.swift; path = Sources/CryptoSwift/SHA1.swift; sourceTree = "<group>"; };
+		000000000650 /* SHA2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA2.swift; path = Sources/CryptoSwift/SHA2.swift; sourceTree = "<group>"; };
+		000000000660 /* SHA3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA3.swift; path = Sources/CryptoSwift/SHA3.swift; sourceTree = "<group>"; };
+		000000000670 /* StreamDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamDecryptor.swift; path = Sources/CryptoSwift/StreamDecryptor.swift; sourceTree = "<group>"; };
+		000000000680 /* StreamEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamEncryptor.swift; path = Sources/CryptoSwift/StreamEncryptor.swift; sourceTree = "<group>"; };
+		000000000690 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "Sources/CryptoSwift/String+Extension.swift"; sourceTree = "<group>"; };
+		0000000006A0 /* UInt128.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UInt128.swift; path = Sources/CryptoSwift/UInt128.swift; sourceTree = "<group>"; };
+		0000000006B0 /* UInt16+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt16+Extension.swift"; path = "Sources/CryptoSwift/UInt16+Extension.swift"; sourceTree = "<group>"; };
+		0000000006C0 /* UInt32+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt32+Extension.swift"; path = "Sources/CryptoSwift/UInt32+Extension.swift"; sourceTree = "<group>"; };
+		0000000006D0 /* UInt64+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt64+Extension.swift"; path = "Sources/CryptoSwift/UInt64+Extension.swift"; sourceTree = "<group>"; };
+		0000000006E0 /* UInt8+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt8+Extension.swift"; path = "Sources/CryptoSwift/UInt8+Extension.swift"; sourceTree = "<group>"; };
+		0000000006F0 /* Updatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Updatable.swift; path = Sources/CryptoSwift/Updatable.swift; sourceTree = "<group>"; };
+		000000000700 /* Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = Sources/CryptoSwift/Utils.swift; sourceTree = "<group>"; };
+		000000000710 /* ZeroPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ZeroPadding.swift; path = Sources/CryptoSwift/ZeroPadding.swift; sourceTree = "<group>"; };
+		000000000730 /* Mockingjay.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Mockingjay.h; path = Sources/Mockingjay/Mockingjay.h; sourceTree = "<group>"; };
+		000000000740 /* Mockingjay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Mockingjay.swift; path = Sources/Mockingjay/Mockingjay.swift; sourceTree = "<group>"; };
+		000000000750 /* MockingjayProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockingjayProtocol.swift; path = Sources/Mockingjay/MockingjayProtocol.swift; sourceTree = "<group>"; };
+		000000000760 /* Builders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Builders.swift; path = Sources/Mockingjay/Builders.swift; sourceTree = "<group>"; };
+		000000000770 /* Matchers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Matchers.swift; path = Sources/Mockingjay/Matchers.swift; sourceTree = "<group>"; };
+		000000000780 /* NSURLSessionConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSURLSessionConfiguration.swift; path = Sources/Mockingjay/NSURLSessionConfiguration.swift; sourceTree = "<group>"; };
+		000000000790 /* MockingjayURLSessionConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MockingjayURLSessionConfiguration.m; path = Sources/Mockingjay/MockingjayURLSessionConfiguration.m; sourceTree = "<group>"; };
+		0000000007B0 /* XCTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCTest.swift; path = Sources/Mockingjay/XCTest.swift; sourceTree = "<group>"; };
+		0000000007C0 /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
+		0000000007D0 /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
+		0000000007E0 /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
+		0000000007F0 /* NimbleEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleEnvironment.swift; path = Sources/Nimble/Adapters/NimbleEnvironment.swift; sourceTree = "<group>"; };
+		000000000800 /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
+		000000000810 /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
+		000000000820 /* NMBObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBObjCMatcher.swift; path = Sources/Nimble/Adapters/NMBObjCMatcher.swift; sourceTree = "<group>"; };
+		000000000830 /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
+		000000000840 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
+		000000000850 /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
+		000000000860 /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
+		000000000870 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
+		000000000880 /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
+		000000000890 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
+		0000000008A0 /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Matchers/Async.swift; sourceTree = "<group>"; };
+		0000000008B0 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
+		0000000008C0 /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
+		0000000008D0 /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
+		0000000008E0 /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
+		0000000008F0 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
+		000000000900 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
+		000000000910 /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
+		000000000920 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
+		000000000930 /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
+		000000000940 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
+		000000000950 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
+		000000000960 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
+		000000000970 /* BeVoid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeVoid.swift; path = Sources/Nimble/Matchers/BeVoid.swift; sourceTree = "<group>"; };
+		000000000980 /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
+		000000000990 /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
+		0000000009A0 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
+		0000000009B0 /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Sources/Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
+		0000000009C0 /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
+		0000000009D0 /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
+		0000000009E0 /* MatcherFunc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherFunc.swift; path = Sources/Nimble/Matchers/MatcherFunc.swift; sourceTree = "<group>"; };
+		0000000009F0 /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
+		000000000A00 /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
+		000000000A10 /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
+		000000000A20 /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
+		000000000A30 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
+		000000000A40 /* SatisfyAllOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAllOf.swift; path = Sources/Nimble/Matchers/SatisfyAllOf.swift; sourceTree = "<group>"; };
+		000000000A50 /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
+		000000000A60 /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
+		000000000A70 /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
+		000000000A80 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
+		000000000A90 /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
+		000000000AA0 /* Await.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Await.swift; path = Sources/Nimble/Utils/Await.swift; sourceTree = "<group>"; };
+		000000000AB0 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
+		000000000AC0 /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Sources/Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
+		000000000AD0 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
+		000000000AE0 /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
+		000000000AF0 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
+		000000000B00 /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
+		000000000B10 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
+		000000000B20 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
+		000000000B30 /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
+		000000000B40 /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
+		000000000B50 /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
+		000000000B60 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
+		000000000B70 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
+		000000000B80 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
+		000000000B90 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
+		000000000BA0 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
+		000000000BB0 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		000000000BC0 /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
+		000000000BD0 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		000000000BE0 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
+		000000000BF0 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
+		000000000C00 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Mach/CwlPreconditionTesting.h; sourceTree = "<group>"; };
+		000000000C10 /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
+		000000000C20 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
+		000000000C30 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Quick/Configuration/Configuration.swift; sourceTree = "<group>"; };
+		000000000C40 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
+		000000000C50 /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
+		000000000C60 /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
+		000000000C70 /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
+		000000000C80 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
+		000000000C90 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
+		000000000CA0 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
+		000000000CB0 /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
+		000000000CC0 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
+		000000000CD0 /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
+		000000000CE0 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
+		000000000CF0 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
+		000000000D00 /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
+		000000000D10 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
+		000000000D20 /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
+		000000000D30 /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
+		000000000D40 /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Sources/Quick/World.swift; sourceTree = "<group>"; };
+		000000000D50 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
+		000000000D60 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
+		000000000D70 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
+		000000000D80 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Sources/QuickObjectiveC/DSL/QCKDSL.m; sourceTree = "<group>"; };
+		000000000D90 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
+		000000000DA0 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
+		000000000DB0 /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
+		000000000DC0 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
+		000000000DD0 /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
+		000000000DE0 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickSpecBase/QuickSpecBase.m; sourceTree = "<group>"; };
+		000000000DF0 /* URITemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URITemplate.swift; path = Sources/URITemplate.swift; sourceTree = "<group>"; };
+		000000000E10 /* Cara.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = Cara.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		000000000E20 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		000000000E30 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		000000000E80 /* Cara.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Cara.framework; path = Cara.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000EE0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		000000001010 /* Cara.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Cara.xcconfig; sourceTree = "<group>"; };
+		000000001020 /* Cara.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Cara.modulemap; sourceTree = "<group>"; };
+		000000001030 /* Cara-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Cara-umbrella.h"; sourceTree = "<group>"; };
+		000000001050 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000001060 /* Cara-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Cara-prefix.pch"; sourceTree = "<group>"; };
+		000000001070 /* Cara-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Cara-dummy.m"; sourceTree = "<group>"; };
+		0000000010D0 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CryptoSwift.framework; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0000000015E0 /* CryptoSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.xcconfig; sourceTree = "<group>"; };
+		0000000015F0 /* CryptoSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CryptoSwift.modulemap; sourceTree = "<group>"; };
+		000000001600 /* CryptoSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-umbrella.h"; sourceTree = "<group>"; };
+		000000001620 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000001630 /* CryptoSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-prefix.pch"; sourceTree = "<group>"; };
+		000000001640 /* CryptoSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CryptoSwift-dummy.m"; sourceTree = "<group>"; };
+		0000000016A0 /* Mockingjay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Mockingjay.framework; path = Mockingjay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000001790 /* Mockingjay.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Mockingjay.xcconfig; sourceTree = "<group>"; };
+		0000000017A0 /* Mockingjay.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Mockingjay.modulemap; sourceTree = "<group>"; };
+		0000000017B0 /* Mockingjay-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Mockingjay-umbrella.h"; sourceTree = "<group>"; };
+		0000000017D0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0000000017E0 /* Mockingjay-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Mockingjay-prefix.pch"; sourceTree = "<group>"; };
+		0000000017F0 /* Mockingjay-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Mockingjay-dummy.m"; sourceTree = "<group>"; };
+		000000001850 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000001D10 /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
+		000000001D20 /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
+		000000001D30 /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
+		000000001D50 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000001D60 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
+		000000001D70 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
+		000000001DD0 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Quick.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000002020 /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
+		000000002030 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
+		000000002040 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
+		000000002060 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000002070 /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
+		000000002080 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
+		0000000020E0 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = URITemplate.framework; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000002160 /* URITemplate.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = URITemplate.xcconfig; sourceTree = "<group>"; };
+		000000002170 /* URITemplate.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = URITemplate.modulemap; sourceTree = "<group>"; };
+		000000002180 /* URITemplate-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-umbrella.h"; sourceTree = "<group>"; };
+		0000000021A0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0000000021B0 /* URITemplate-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-prefix.pch"; sourceTree = "<group>"; };
+		0000000021C0 /* URITemplate-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "URITemplate-dummy.m"; sourceTree = "<group>"; };
+		000000002220 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Tests.framework; path = "Pods-Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000002290 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		0000000022A0 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		0000000022B0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0000000022C0 /* Pods-Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Tests.modulemap"; sourceTree = "<group>"; };
+		0000000022D0 /* Pods-Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tests-umbrella.h"; sourceTree = "<group>"; };
+		0000000022F0 /* Pods-Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-frameworks.sh"; sourceTree = "<group>"; };
+		000000002300 /* Pods-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-resources.sh"; sourceTree = "<group>"; };
+		000000002310 /* Pods-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		000000002320 /* Pods-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		000000002330 /* Pods-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tests-dummy.m"; sourceTree = "<group>"; };
+		000000002350 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		0000000023C0 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000002440 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		000000000E80 /* Frameworks */ = {
+		000000000EB0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000002370 /* CryptoSwift.framework in Frameworks */,
-				000000000EC0 /* Foundation.framework in Frameworks */,
+				0000000023D0 /* CryptoSwift.framework in Frameworks */,
+				000000000EF0 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000010A0 /* Frameworks */ = {
+		000000001100 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000010C0 /* Foundation.framework in Frameworks */,
+				000000001120 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001670 /* Frameworks */ = {
+		0000000016D0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001690 /* Foundation.framework in Frameworks */,
-				0000000023F0 /* URITemplate.framework in Frameworks */,
-				000000002300 /* XCTest.framework in Frameworks */,
+				0000000016F0 /* Foundation.framework in Frameworks */,
+				000000002450 /* URITemplate.framework in Frameworks */,
+				000000002360 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001820 /* Frameworks */ = {
+		000000001880 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001840 /* Foundation.framework in Frameworks */,
+				0000000018A0 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001DA0 /* Frameworks */ = {
+		000000001E00 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001DC0 /* Foundation.framework in Frameworks */,
-				000000002310 /* XCTest.framework in Frameworks */,
+				000000001E20 /* Foundation.framework in Frameworks */,
+				000000002370 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000020B0 /* Frameworks */ = {
+		000000002110 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000020D0 /* Foundation.framework in Frameworks */,
+				000000002130 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000021F0 /* Frameworks */ = {
+		000000002250 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000002210 /* Foundation.framework in Frameworks */,
+				000000002270 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -632,13 +632,13 @@
 		000000000020 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				000000000E50 /* Cara.framework */,
-				000000001070 /* CryptoSwift.framework */,
-				000000001640 /* Mockingjay.framework */,
-				0000000017F0 /* Nimble.framework */,
-				0000000021C0 /* Pods_Tests.framework */,
-				000000001D70 /* Quick.framework */,
-				000000002080 /* URITemplate.framework */,
+				000000000E80 /* Cara.framework */,
+				0000000010D0 /* CryptoSwift.framework */,
+				0000000016A0 /* Mockingjay.framework */,
+				000000001850 /* Nimble.framework */,
+				000000002220 /* Pods_Tests.framework */,
+				000000001DD0 /* Quick.framework */,
+				0000000020E0 /* URITemplate.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -646,9 +646,9 @@
 		000000000060 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				000000002360 /* CryptoSwift.framework */,
-				0000000023E0 /* URITemplate.framework */,
-				000000000EA0 /* iOS */,
+				0000000023C0 /* CryptoSwift.framework */,
+				000000002440 /* URITemplate.framework */,
+				000000000ED0 /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -656,7 +656,7 @@
 		000000000070 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000002220 /* Pods-Tests */,
+				000000002280 /* Pods-Tests */,
 			);
 			name = "Targets Support Files";
 			sourceTree = "<group>";
@@ -688,11 +688,11 @@
 				000000000120 /* Configuration */,
 				000000000140 /* Extensions */,
 				000000000170 /* Logger */,
-				000000000DD0 /* Pod */,
-				000000000190 /* Request */,
-				0000000001D0 /* Serializer */,
-				000000000200 /* Service */,
-				000000000FA0 /* Support Files */,
+				000000000E00 /* Pod */,
+				0000000001C0 /* Request */,
+				000000000200 /* Serializer */,
+				000000000230 /* Service */,
+				000000001000 /* Support Files */,
 			);
 			name = Cara;
 			path = ../..;
@@ -701,207 +701,211 @@
 		0000000000B0 /* CryptoSwift */ = {
 			isa = PBXGroup;
 			children = (
-				000000000250 /* AEAD.swift */,
-				000000000260 /* AEADChaCha20Poly1305.swift */,
-				000000000280 /* AES.swift */,
-				000000000470 /* AES+Foundation.swift */,
-				000000000270 /* AES.Cryptors.swift */,
-				000000000290 /* Array+Extension.swift */,
-				000000000480 /* Array+Foundation.swift */,
-				0000000002A0 /* Authenticator.swift */,
-				0000000002B0 /* BatchedCollection.swift */,
-				0000000002C0 /* Bit.swift */,
-				0000000002D0 /* BlockCipher.swift */,
-				0000000002E0 /* BlockDecryptor.swift */,
-				0000000002F0 /* BlockEncryptor.swift */,
-				000000000300 /* BlockMode.swift */,
-				000000000310 /* BlockModeOptions.swift */,
-				0000000003B0 /* Blowfish.swift */,
-				000000000490 /* Blowfish+Foundation.swift */,
-				000000000320 /* CBC.swift */,
-				0000000003C0 /* CBCMAC.swift */,
-				000000000330 /* CCM.swift */,
-				000000000340 /* CFB.swift */,
-				0000000003D0 /* ChaCha20.swift */,
-				0000000004A0 /* ChaCha20+Foundation.swift */,
-				0000000003E0 /* Checksum.swift */,
-				0000000003F0 /* Cipher.swift */,
-				000000000350 /* CipherModeWorker.swift */,
-				000000000400 /* CMAC.swift */,
-				000000000410 /* Collection+Extension.swift */,
-				000000000420 /* CompactMap.swift */,
-				000000000430 /* Cryptor.swift */,
-				000000000440 /* Cryptors.swift */,
-				000000000360 /* CTR.swift */,
-				0000000004B0 /* Data+Extension.swift */,
-				000000000450 /* Digest.swift */,
-				000000000460 /* DigestType.swift */,
-				000000000370 /* ECB.swift */,
-				000000000380 /* GCM.swift */,
-				000000000500 /* Generics.swift */,
-				000000000510 /* HKDF.swift */,
-				000000000520 /* HMAC.swift */,
-				0000000004C0 /* HMAC+Foundation.swift */,
-				000000000530 /* Int+Extension.swift */,
-				000000000540 /* MD5.swift */,
-				000000000550 /* NoPadding.swift */,
-				000000000390 /* OFB.swift */,
-				000000000560 /* Operators.swift */,
-				000000000570 /* Padding.swift */,
-				000000000580 /* PBKDF1.swift */,
-				000000000590 /* PBKDF2.swift */,
-				0000000003A0 /* PCBC.swift */,
-				0000000005A0 /* PKCS5.swift */,
-				0000000005B0 /* PKCS7.swift */,
-				0000000005C0 /* PKCS7Padding.swift */,
-				0000000005D0 /* Poly1305.swift */,
-				0000000005E0 /* Rabbit.swift */,
-				0000000004D0 /* Rabbit+Foundation.swift */,
-				0000000005F0 /* RandomBytesSequence.swift */,
-				000000000600 /* SecureBytes.swift */,
-				000000000610 /* SHA1.swift */,
-				000000000620 /* SHA2.swift */,
-				000000000630 /* SHA3.swift */,
-				000000000640 /* StreamDecryptor.swift */,
-				000000000650 /* StreamEncryptor.swift */,
-				000000000660 /* String+Extension.swift */,
-				0000000004E0 /* String+FoundationExtension.swift */,
-				000000000670 /* UInt128.swift */,
-				000000000680 /* UInt16+Extension.swift */,
-				000000000690 /* UInt32+Extension.swift */,
-				0000000006A0 /* UInt64+Extension.swift */,
-				0000000006B0 /* UInt8+Extension.swift */,
-				0000000006C0 /* Updatable.swift */,
-				0000000006D0 /* Utils.swift */,
-				0000000004F0 /* Utils+Foundation.swift */,
-				0000000006E0 /* ZeroPadding.swift */,
-				000000001570 /* Support Files */,
+				000000000280 /* AEAD.swift */,
+				000000000290 /* AEADChaCha20Poly1305.swift */,
+				0000000002B0 /* AES.swift */,
+				0000000004A0 /* AES+Foundation.swift */,
+				0000000002A0 /* AES.Cryptors.swift */,
+				0000000002C0 /* Array+Extension.swift */,
+				0000000004B0 /* Array+Foundation.swift */,
+				0000000002D0 /* Authenticator.swift */,
+				0000000002E0 /* BatchedCollection.swift */,
+				0000000002F0 /* Bit.swift */,
+				000000000300 /* BlockCipher.swift */,
+				000000000310 /* BlockDecryptor.swift */,
+				000000000320 /* BlockEncryptor.swift */,
+				000000000330 /* BlockMode.swift */,
+				000000000340 /* BlockModeOptions.swift */,
+				0000000003E0 /* Blowfish.swift */,
+				0000000004C0 /* Blowfish+Foundation.swift */,
+				000000000350 /* CBC.swift */,
+				0000000003F0 /* CBCMAC.swift */,
+				000000000360 /* CCM.swift */,
+				000000000370 /* CFB.swift */,
+				000000000400 /* ChaCha20.swift */,
+				0000000004D0 /* ChaCha20+Foundation.swift */,
+				000000000410 /* Checksum.swift */,
+				000000000420 /* Cipher.swift */,
+				000000000380 /* CipherModeWorker.swift */,
+				000000000430 /* CMAC.swift */,
+				000000000440 /* Collection+Extension.swift */,
+				000000000450 /* CompactMap.swift */,
+				000000000460 /* Cryptor.swift */,
+				000000000470 /* Cryptors.swift */,
+				000000000390 /* CTR.swift */,
+				0000000004E0 /* Data+Extension.swift */,
+				000000000480 /* Digest.swift */,
+				000000000490 /* DigestType.swift */,
+				0000000003A0 /* ECB.swift */,
+				0000000003B0 /* GCM.swift */,
+				000000000530 /* Generics.swift */,
+				000000000540 /* HKDF.swift */,
+				000000000550 /* HMAC.swift */,
+				0000000004F0 /* HMAC+Foundation.swift */,
+				000000000560 /* Int+Extension.swift */,
+				000000000570 /* MD5.swift */,
+				000000000580 /* NoPadding.swift */,
+				0000000003C0 /* OFB.swift */,
+				000000000590 /* Operators.swift */,
+				0000000005A0 /* Padding.swift */,
+				0000000005B0 /* PBKDF1.swift */,
+				0000000005C0 /* PBKDF2.swift */,
+				0000000003D0 /* PCBC.swift */,
+				0000000005D0 /* PKCS5.swift */,
+				0000000005E0 /* PKCS7.swift */,
+				0000000005F0 /* PKCS7Padding.swift */,
+				000000000600 /* Poly1305.swift */,
+				000000000610 /* Rabbit.swift */,
+				000000000500 /* Rabbit+Foundation.swift */,
+				000000000620 /* RandomBytesSequence.swift */,
+				000000000630 /* SecureBytes.swift */,
+				000000000640 /* SHA1.swift */,
+				000000000650 /* SHA2.swift */,
+				000000000660 /* SHA3.swift */,
+				000000000670 /* StreamDecryptor.swift */,
+				000000000680 /* StreamEncryptor.swift */,
+				000000000690 /* String+Extension.swift */,
+				000000000510 /* String+FoundationExtension.swift */,
+				0000000006A0 /* UInt128.swift */,
+				0000000006B0 /* UInt16+Extension.swift */,
+				0000000006C0 /* UInt32+Extension.swift */,
+				0000000006D0 /* UInt64+Extension.swift */,
+				0000000006E0 /* UInt8+Extension.swift */,
+				0000000006F0 /* Updatable.swift */,
+				000000000700 /* Utils.swift */,
+				000000000520 /* Utils+Foundation.swift */,
+				000000000710 /* ZeroPadding.swift */,
+				0000000015D0 /* Support Files */,
 			);
+			name = CryptoSwift;
 			path = CryptoSwift;
 			sourceTree = "<group>";
 		};
 		0000000000C0 /* Mockingjay */ = {
 			isa = PBXGroup;
 			children = (
-				0000000006F0 /* Core */,
-				000000001720 /* Support Files */,
-				000000000770 /* XCTest */,
+				000000000720 /* Core */,
+				000000001780 /* Support Files */,
+				0000000007A0 /* XCTest */,
 			);
+			name = Mockingjay;
 			path = Mockingjay;
 			sourceTree = "<group>";
 		};
 		0000000000D0 /* Nimble */ = {
 			isa = PBXGroup;
 			children = (
-				000000000790 /* AdapterProtocols.swift */,
-				000000000860 /* AllPass.swift */,
-				0000000007A0 /* AssertionDispatcher.swift */,
-				0000000007B0 /* AssertionRecorder.swift */,
-				000000000870 /* Async.swift */,
-				000000000A70 /* Await.swift */,
-				000000000880 /* BeAKindOf.swift */,
-				000000000890 /* BeAnInstanceOf.swift */,
-				0000000008A0 /* BeCloseTo.swift */,
-				0000000008B0 /* BeEmpty.swift */,
-				0000000008C0 /* BeginWith.swift */,
-				0000000008D0 /* BeGreaterThan.swift */,
-				0000000008E0 /* BeGreaterThanOrEqualTo.swift */,
-				0000000008F0 /* BeIdenticalTo.swift */,
-				000000000900 /* BeLessThan.swift */,
-				000000000910 /* BeLessThanOrEqual.swift */,
-				000000000920 /* BeLogical.swift */,
-				000000000930 /* BeNil.swift */,
-				000000000940 /* BeVoid.swift */,
-				000000000950 /* Contain.swift */,
-				000000000960 /* ContainElementSatisfying.swift */,
-				000000000BA0 /* CwlBadInstructionException.swift */,
-				000000000BB0 /* CwlCatchBadInstruction.swift */,
-				000000000B50 /* CwlCatchException.h */,
-				000000000B40 /* CwlCatchException.m */,
-				000000000B30 /* CwlCatchException.swift */,
-				000000000BC0 /* CwlDarwinDefinitions.swift */,
-				000000000B70 /* CwlMachBadInstructionHandler.h */,
-				000000000B60 /* CwlMachBadInstructionHandler.m */,
-				000000000BD0 /* CwlPreconditionTesting.h */,
-				000000000AC0 /* DSL.h */,
-				000000000AD0 /* DSL.m */,
-				000000000810 /* DSL.swift */,
-				000000000800 /* DSL+Wait.swift */,
-				000000000970 /* EndWith.swift */,
-				000000000980 /* Equal.swift */,
-				000000000A80 /* Errors.swift */,
-				000000000820 /* Expectation.swift */,
-				000000000830 /* ExpectationMessage.swift */,
-				000000000840 /* Expression.swift */,
-				000000000850 /* FailureMessage.swift */,
-				000000000A90 /* Functional.swift */,
-				000000000990 /* HaveCount.swift */,
-				000000000B80 /* mach_excServer.c */,
-				000000000B90 /* mach_excServer.h */,
-				0000000009A0 /* Match.swift */,
-				0000000009B0 /* MatcherFunc.swift */,
-				0000000009C0 /* MatcherProtocols.swift */,
-				0000000009D0 /* MatchError.swift */,
-				000000000A60 /* Nimble.h */,
-				0000000007C0 /* NimbleEnvironment.swift */,
-				0000000007D0 /* NimbleXCTestHandler.swift */,
-				000000000AE0 /* NMBExceptionCapture.h */,
-				000000000AF0 /* NMBExceptionCapture.m */,
-				0000000007E0 /* NMBExpectation.swift */,
-				0000000007F0 /* NMBObjCMatcher.swift */,
-				000000000B00 /* NMBStringify.h */,
-				000000000B10 /* NMBStringify.m */,
-				0000000009E0 /* PostNotification.swift */,
-				0000000009F0 /* Predicate.swift */,
-				000000000A00 /* RaisesException.swift */,
-				000000000A10 /* SatisfyAllOf.swift */,
-				000000000A20 /* SatisfyAnyOf.swift */,
-				000000000AA0 /* SourceLocation.swift */,
-				000000000AB0 /* Stringers.swift */,
-				000000000A30 /* ThrowAssertion.swift */,
-				000000000A40 /* ThrowError.swift */,
-				000000000A50 /* ToSucceed.swift */,
-				000000000B20 /* XCTestObservationCenter+Register.m */,
-				000000001CA0 /* Support Files */,
+				0000000007C0 /* AdapterProtocols.swift */,
+				000000000890 /* AllPass.swift */,
+				0000000007D0 /* AssertionDispatcher.swift */,
+				0000000007E0 /* AssertionRecorder.swift */,
+				0000000008A0 /* Async.swift */,
+				000000000AA0 /* Await.swift */,
+				0000000008B0 /* BeAKindOf.swift */,
+				0000000008C0 /* BeAnInstanceOf.swift */,
+				0000000008D0 /* BeCloseTo.swift */,
+				0000000008E0 /* BeEmpty.swift */,
+				0000000008F0 /* BeginWith.swift */,
+				000000000900 /* BeGreaterThan.swift */,
+				000000000910 /* BeGreaterThanOrEqualTo.swift */,
+				000000000920 /* BeIdenticalTo.swift */,
+				000000000930 /* BeLessThan.swift */,
+				000000000940 /* BeLessThanOrEqual.swift */,
+				000000000950 /* BeLogical.swift */,
+				000000000960 /* BeNil.swift */,
+				000000000970 /* BeVoid.swift */,
+				000000000980 /* Contain.swift */,
+				000000000990 /* ContainElementSatisfying.swift */,
+				000000000BD0 /* CwlBadInstructionException.swift */,
+				000000000BE0 /* CwlCatchBadInstruction.swift */,
+				000000000B80 /* CwlCatchException.h */,
+				000000000B70 /* CwlCatchException.m */,
+				000000000B60 /* CwlCatchException.swift */,
+				000000000BF0 /* CwlDarwinDefinitions.swift */,
+				000000000BA0 /* CwlMachBadInstructionHandler.h */,
+				000000000B90 /* CwlMachBadInstructionHandler.m */,
+				000000000C00 /* CwlPreconditionTesting.h */,
+				000000000AF0 /* DSL.h */,
+				000000000B00 /* DSL.m */,
+				000000000840 /* DSL.swift */,
+				000000000830 /* DSL+Wait.swift */,
+				0000000009A0 /* EndWith.swift */,
+				0000000009B0 /* Equal.swift */,
+				000000000AB0 /* Errors.swift */,
+				000000000850 /* Expectation.swift */,
+				000000000860 /* ExpectationMessage.swift */,
+				000000000870 /* Expression.swift */,
+				000000000880 /* FailureMessage.swift */,
+				000000000AC0 /* Functional.swift */,
+				0000000009C0 /* HaveCount.swift */,
+				000000000BB0 /* mach_excServer.c */,
+				000000000BC0 /* mach_excServer.h */,
+				0000000009D0 /* Match.swift */,
+				0000000009E0 /* MatcherFunc.swift */,
+				0000000009F0 /* MatcherProtocols.swift */,
+				000000000A00 /* MatchError.swift */,
+				000000000A90 /* Nimble.h */,
+				0000000007F0 /* NimbleEnvironment.swift */,
+				000000000800 /* NimbleXCTestHandler.swift */,
+				000000000B10 /* NMBExceptionCapture.h */,
+				000000000B20 /* NMBExceptionCapture.m */,
+				000000000810 /* NMBExpectation.swift */,
+				000000000820 /* NMBObjCMatcher.swift */,
+				000000000B30 /* NMBStringify.h */,
+				000000000B40 /* NMBStringify.m */,
+				000000000A10 /* PostNotification.swift */,
+				000000000A20 /* Predicate.swift */,
+				000000000A30 /* RaisesException.swift */,
+				000000000A40 /* SatisfyAllOf.swift */,
+				000000000A50 /* SatisfyAnyOf.swift */,
+				000000000AD0 /* SourceLocation.swift */,
+				000000000AE0 /* Stringers.swift */,
+				000000000A60 /* ThrowAssertion.swift */,
+				000000000A70 /* ThrowError.swift */,
+				000000000A80 /* ToSucceed.swift */,
+				000000000B50 /* XCTestObservationCenter+Register.m */,
+				000000001D00 /* Support Files */,
 			);
+			name = Nimble;
 			path = Nimble;
 			sourceTree = "<group>";
 		};
 		0000000000E0 /* Quick */ = {
 			isa = PBXGroup;
 			children = (
-				000000000BE0 /* Behavior.swift */,
-				000000000BF0 /* Callsite.swift */,
-				000000000C80 /* Closures.swift */,
-				000000000C00 /* Configuration.swift */,
-				000000000C10 /* DSL.swift */,
-				000000000C30 /* ErrorUtility.swift */,
-				000000000C40 /* Example.swift */,
-				000000000C50 /* ExampleGroup.swift */,
-				000000000C90 /* ExampleHooks.swift */,
-				000000000C60 /* ExampleMetadata.swift */,
-				000000000C70 /* Filter.swift */,
-				000000000CA0 /* HooksPhase.swift */,
-				000000000CC0 /* NSBundle+CurrentTestBundle.swift */,
-				000000000CD0 /* NSString+C99ExtendedIdentifier.swift */,
-				000000000D40 /* QCKDSL.h */,
-				000000000D50 /* QCKDSL.m */,
-				000000000D60 /* Quick.h */,
-				000000000D20 /* QuickConfiguration.h */,
-				000000000D30 /* QuickConfiguration.m */,
-				000000000CE0 /* QuickSelectedTestSuiteBuilder.swift */,
-				000000000D70 /* QuickSpec.h */,
-				000000000D80 /* QuickSpec.m */,
-				000000000DA0 /* QuickSpecBase.h */,
-				000000000DB0 /* QuickSpecBase.m */,
-				000000000CF0 /* QuickTestSuite.swift */,
-				000000000CB0 /* SuiteHooks.swift */,
-				000000000D00 /* URL+FileName.swift */,
-				000000000D10 /* World.swift */,
-				000000000C20 /* World+DSL.swift */,
-				000000000D90 /* XCTestSuite+QuickTestSuiteBuilder.m */,
-				000000001FB0 /* Support Files */,
+				000000000C10 /* Behavior.swift */,
+				000000000C20 /* Callsite.swift */,
+				000000000CB0 /* Closures.swift */,
+				000000000C30 /* Configuration.swift */,
+				000000000C40 /* DSL.swift */,
+				000000000C60 /* ErrorUtility.swift */,
+				000000000C70 /* Example.swift */,
+				000000000C80 /* ExampleGroup.swift */,
+				000000000CC0 /* ExampleHooks.swift */,
+				000000000C90 /* ExampleMetadata.swift */,
+				000000000CA0 /* Filter.swift */,
+				000000000CD0 /* HooksPhase.swift */,
+				000000000CF0 /* NSBundle+CurrentTestBundle.swift */,
+				000000000D00 /* NSString+C99ExtendedIdentifier.swift */,
+				000000000D70 /* QCKDSL.h */,
+				000000000D80 /* QCKDSL.m */,
+				000000000D90 /* Quick.h */,
+				000000000D50 /* QuickConfiguration.h */,
+				000000000D60 /* QuickConfiguration.m */,
+				000000000D10 /* QuickSelectedTestSuiteBuilder.swift */,
+				000000000DA0 /* QuickSpec.h */,
+				000000000DB0 /* QuickSpec.m */,
+				000000000DD0 /* QuickSpecBase.h */,
+				000000000DE0 /* QuickSpecBase.m */,
+				000000000D20 /* QuickTestSuite.swift */,
+				000000000CE0 /* SuiteHooks.swift */,
+				000000000D30 /* URL+FileName.swift */,
+				000000000D40 /* World.swift */,
+				000000000C50 /* World+DSL.swift */,
+				000000000DC0 /* XCTestSuite+QuickTestSuiteBuilder.m */,
+				000000002010 /* Support Files */,
 			);
+			name = Quick;
 			path = Quick;
 			sourceTree = "<group>";
 		};
@@ -909,15 +913,17 @@
 			isa = PBXGroup;
 			children = (
 			);
+			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
 		000000000100 /* URITemplate */ = {
 			isa = PBXGroup;
 			children = (
-				000000000DC0 /* URITemplate.swift */,
-				0000000020F0 /* Support Files */,
+				000000000DF0 /* URITemplate.swift */,
+				000000002150 /* Support Files */,
 			);
+			name = URITemplate;
 			path = URITemplate;
 			sourceTree = "<group>";
 		};
@@ -943,186 +949,186 @@
 		000000000170 /* Logger */ = {
 			isa = PBXGroup;
 			children = (
-				000000000180 /* ConsoleLogger.swift */,
-				9D21FEFF21D92A4B006EF131 /* OSLog+Request.swift */,
-				9D21FF0121D92A5F006EF131 /* Configuration+Logger.swift */,
-				9D21FF0321D92A70006EF131 /* Logger.swift */,
+				000000000180 /* Configuration+Logger.swift */,
+				000000000190 /* ConsoleLogger.swift */,
+				0000000001A0 /* Logger.swift */,
+				0000000001B0 /* OSLog+Request.swift */,
 			);
 			name = Logger;
 			path = Sources/Logger;
 			sourceTree = "<group>";
 		};
-		000000000190 /* Request */ = {
+		0000000001C0 /* Request */ = {
 			isa = PBXGroup;
 			children = (
-				0000000001B0 /* Request.swift */,
-				0000000001A0 /* Request+URLRequest.swift */,
-				0000000001C0 /* RequestMethod.swift */,
+				0000000001E0 /* Request.swift */,
+				0000000001D0 /* Request+URLRequest.swift */,
+				0000000001F0 /* RequestMethod.swift */,
 			);
 			name = Request;
 			path = Sources/Request;
 			sourceTree = "<group>";
 		};
-		0000000001D0 /* Serializer */ = {
+		000000000200 /* Serializer */ = {
 			isa = PBXGroup;
 			children = (
-				0000000001E0 /* CodableSerializer.swift */,
-				0000000001F0 /* Serializer.swift */,
+				000000000210 /* CodableSerializer.swift */,
+				000000000220 /* Serializer.swift */,
 			);
 			name = Serializer;
 			path = Sources/Serializer;
 			sourceTree = "<group>";
 		};
-		000000000200 /* Service */ = {
+		000000000230 /* Service */ = {
 			isa = PBXGroup;
 			children = (
-				000000000210 /* NetworkService.swift */,
-				000000000220 /* PublicKeyPinningService.swift */,
-				000000000230 /* ResponseError.swift */,
-				000000000240 /* Service.swift */,
+				000000000240 /* NetworkService.swift */,
+				000000000250 /* PublicKeyPinningService.swift */,
+				000000000260 /* ResponseError.swift */,
+				000000000270 /* Service.swift */,
 			);
 			name = Service;
 			path = Sources/Service;
 			sourceTree = "<group>";
 		};
-		0000000006F0 /* Core */ = {
+		000000000720 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				000000000730 /* Builders.swift */,
-				000000000740 /* Matchers.swift */,
-				000000000700 /* Mockingjay.h */,
-				000000000710 /* Mockingjay.swift */,
-				000000000720 /* MockingjayProtocol.swift */,
-				000000000760 /* MockingjayURLSessionConfiguration.m */,
-				000000000750 /* NSURLSessionConfiguration.swift */,
+				000000000760 /* Builders.swift */,
+				000000000770 /* Matchers.swift */,
+				000000000730 /* Mockingjay.h */,
+				000000000740 /* Mockingjay.swift */,
+				000000000750 /* MockingjayProtocol.swift */,
+				000000000790 /* MockingjayURLSessionConfiguration.m */,
+				000000000780 /* NSURLSessionConfiguration.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";
 		};
-		000000000770 /* XCTest */ = {
+		0000000007A0 /* XCTest */ = {
 			isa = PBXGroup;
 			children = (
-				000000000780 /* XCTest.swift */,
+				0000000007B0 /* XCTest.swift */,
 			);
 			name = XCTest;
 			sourceTree = "<group>";
 		};
-		000000000DD0 /* Pod */ = {
+		000000000E00 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				000000000DE0 /* Cara.podspec */,
-				000000000DF0 /* LICENSE */,
-				000000000E00 /* README.md */,
+				000000000E10 /* Cara.podspec */,
+				000000000E20 /* LICENSE */,
+				000000000E30 /* README.md */,
 			);
 			name = Pod;
 			sourceTree = "<group>";
 		};
-		000000000EA0 /* iOS */ = {
+		000000000ED0 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				000000000EB0 /* Foundation.framework */,
-				0000000022F0 /* XCTest.framework */,
+				000000000EE0 /* Foundation.framework */,
+				000000002350 /* XCTest.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		000000000FA0 /* Support Files */ = {
+		000000001000 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000000FC0 /* Cara.modulemap */,
-				000000000FB0 /* Cara.xcconfig */,
-				000000001010 /* Cara-dummy.m */,
-				000000001000 /* Cara-prefix.pch */,
-				000000000FD0 /* Cara-umbrella.h */,
-				000000000FF0 /* Info.plist */,
+				000000001020 /* Cara.modulemap */,
+				000000001010 /* Cara.xcconfig */,
+				000000001070 /* Cara-dummy.m */,
+				000000001060 /* Cara-prefix.pch */,
+				000000001030 /* Cara-umbrella.h */,
+				000000001050 /* Info.plist */,
 			);
 			name = "Support Files";
 			path = "Example/Pods/Target Support Files/Cara";
 			sourceTree = "<group>";
 		};
-		000000001570 /* Support Files */ = {
+		0000000015D0 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000001590 /* CryptoSwift.modulemap */,
-				000000001580 /* CryptoSwift.xcconfig */,
-				0000000015E0 /* CryptoSwift-dummy.m */,
-				0000000015D0 /* CryptoSwift-prefix.pch */,
-				0000000015A0 /* CryptoSwift-umbrella.h */,
-				0000000015C0 /* Info.plist */,
+				0000000015F0 /* CryptoSwift.modulemap */,
+				0000000015E0 /* CryptoSwift.xcconfig */,
+				000000001640 /* CryptoSwift-dummy.m */,
+				000000001630 /* CryptoSwift-prefix.pch */,
+				000000001600 /* CryptoSwift-umbrella.h */,
+				000000001620 /* Info.plist */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/CryptoSwift";
 			sourceTree = "<group>";
 		};
-		000000001720 /* Support Files */ = {
+		000000001780 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000001770 /* Info.plist */,
-				000000001740 /* Mockingjay.modulemap */,
-				000000001730 /* Mockingjay.xcconfig */,
-				000000001790 /* Mockingjay-dummy.m */,
-				000000001780 /* Mockingjay-prefix.pch */,
-				000000001750 /* Mockingjay-umbrella.h */,
+				0000000017D0 /* Info.plist */,
+				0000000017A0 /* Mockingjay.modulemap */,
+				000000001790 /* Mockingjay.xcconfig */,
+				0000000017F0 /* Mockingjay-dummy.m */,
+				0000000017E0 /* Mockingjay-prefix.pch */,
+				0000000017B0 /* Mockingjay-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Mockingjay";
 			sourceTree = "<group>";
 		};
-		000000001CA0 /* Support Files */ = {
+		000000001D00 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000001CF0 /* Info.plist */,
-				000000001CC0 /* Nimble.modulemap */,
-				000000001CB0 /* Nimble.xcconfig */,
-				000000001D10 /* Nimble-dummy.m */,
-				000000001D00 /* Nimble-prefix.pch */,
-				000000001CD0 /* Nimble-umbrella.h */,
+				000000001D50 /* Info.plist */,
+				000000001D20 /* Nimble.modulemap */,
+				000000001D10 /* Nimble.xcconfig */,
+				000000001D70 /* Nimble-dummy.m */,
+				000000001D60 /* Nimble-prefix.pch */,
+				000000001D30 /* Nimble-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Nimble";
 			sourceTree = "<group>";
 		};
-		000000001FB0 /* Support Files */ = {
+		000000002010 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000002000 /* Info.plist */,
-				000000001FD0 /* Quick.modulemap */,
-				000000001FC0 /* Quick.xcconfig */,
-				000000002020 /* Quick-dummy.m */,
-				000000002010 /* Quick-prefix.pch */,
-				000000001FE0 /* Quick-umbrella.h */,
+				000000002060 /* Info.plist */,
+				000000002030 /* Quick.modulemap */,
+				000000002020 /* Quick.xcconfig */,
+				000000002080 /* Quick-dummy.m */,
+				000000002070 /* Quick-prefix.pch */,
+				000000002040 /* Quick-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Quick";
 			sourceTree = "<group>";
 		};
-		0000000020F0 /* Support Files */ = {
+		000000002150 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000002140 /* Info.plist */,
-				000000002110 /* URITemplate.modulemap */,
-				000000002100 /* URITemplate.xcconfig */,
-				000000002160 /* URITemplate-dummy.m */,
-				000000002150 /* URITemplate-prefix.pch */,
-				000000002120 /* URITemplate-umbrella.h */,
+				0000000021A0 /* Info.plist */,
+				000000002170 /* URITemplate.modulemap */,
+				000000002160 /* URITemplate.xcconfig */,
+				0000000021C0 /* URITemplate-dummy.m */,
+				0000000021B0 /* URITemplate-prefix.pch */,
+				000000002180 /* URITemplate-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/URITemplate";
 			sourceTree = "<group>";
 		};
-		000000002220 /* Pods-Tests */ = {
+		000000002280 /* Pods-Tests */ = {
 			isa = PBXGroup;
 			children = (
-				000000002250 /* Info.plist */,
-				000000002260 /* Pods-Tests.modulemap */,
-				0000000022C0 /* Pods-Tests-acknowledgements.markdown */,
-				0000000022B0 /* Pods-Tests-acknowledgements.plist */,
-				0000000022D0 /* Pods-Tests-dummy.m */,
-				000000002290 /* Pods-Tests-frameworks.sh */,
-				0000000022A0 /* Pods-Tests-resources.sh */,
-				000000002270 /* Pods-Tests-umbrella.h */,
-				000000002240 /* Pods-Tests.debug.xcconfig */,
-				000000002230 /* Pods-Tests.release.xcconfig */,
+				0000000022B0 /* Info.plist */,
+				0000000022C0 /* Pods-Tests.modulemap */,
+				000000002320 /* Pods-Tests-acknowledgements.markdown */,
+				000000002310 /* Pods-Tests-acknowledgements.plist */,
+				000000002330 /* Pods-Tests-dummy.m */,
+				0000000022F0 /* Pods-Tests-frameworks.sh */,
+				000000002300 /* Pods-Tests-resources.sh */,
+				0000000022D0 /* Pods-Tests-umbrella.h */,
+				0000000022A0 /* Pods-Tests.debug.xcconfig */,
+				000000002290 /* Pods-Tests.release.xcconfig */,
 			);
 			name = "Pods-Tests";
 			path = "Target Support Files/Pods-Tests";
@@ -1131,106 +1137,106 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		000000000E60 /* Headers */ = {
+		000000000E90 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000000FE0 /* Cara-umbrella.h in Headers */,
+				000000001040 /* Cara-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001080 /* Headers */ = {
+		0000000010E0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000015B0 /* CryptoSwift-umbrella.h in Headers */,
+				000000001610 /* CryptoSwift-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001650 /* Headers */ = {
+		0000000016B0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001760 /* Mockingjay-umbrella.h in Headers */,
-				000000001700 /* Mockingjay.h in Headers */,
+				0000000017C0 /* Mockingjay-umbrella.h in Headers */,
+				000000001760 /* Mockingjay.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001800 /* Headers */ = {
+		000000001860 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001C60 /* CwlCatchException.h in Headers */,
-				000000001C70 /* CwlMachBadInstructionHandler.h in Headers */,
-				000000001C90 /* CwlPreconditionTesting.h in Headers */,
-				000000001C30 /* DSL.h in Headers */,
-				000000001C80 /* mach_excServer.h in Headers */,
-				000000001CE0 /* Nimble-umbrella.h in Headers */,
-				000000001C20 /* Nimble.h in Headers */,
-				000000001C40 /* NMBExceptionCapture.h in Headers */,
-				000000001C50 /* NMBStringify.h in Headers */,
+				000000001CC0 /* CwlCatchException.h in Headers */,
+				000000001CD0 /* CwlMachBadInstructionHandler.h in Headers */,
+				000000001CF0 /* CwlPreconditionTesting.h in Headers */,
+				000000001C90 /* DSL.h in Headers */,
+				000000001CE0 /* mach_excServer.h in Headers */,
+				000000001D40 /* Nimble-umbrella.h in Headers */,
+				000000001C80 /* Nimble.h in Headers */,
+				000000001CA0 /* NMBExceptionCapture.h in Headers */,
+				000000001CB0 /* NMBStringify.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001D80 /* Headers */ = {
+		000000001DE0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001F70 /* QCKDSL.h in Headers */,
-				000000001FF0 /* Quick-umbrella.h in Headers */,
-				000000001F80 /* Quick.h in Headers */,
-				000000001F60 /* QuickConfiguration.h in Headers */,
-				000000001F90 /* QuickSpec.h in Headers */,
-				000000001FA0 /* QuickSpecBase.h in Headers */,
+				000000001FD0 /* QCKDSL.h in Headers */,
+				000000002050 /* Quick-umbrella.h in Headers */,
+				000000001FE0 /* Quick.h in Headers */,
+				000000001FC0 /* QuickConfiguration.h in Headers */,
+				000000001FF0 /* QuickSpec.h in Headers */,
+				000000002000 /* QuickSpecBase.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000002090 /* Headers */ = {
+		0000000020F0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000002130 /* URITemplate-umbrella.h in Headers */,
+				000000002190 /* URITemplate-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000021D0 /* Headers */ = {
+		000000002230 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000002280 /* Pods-Tests-umbrella.h in Headers */,
+				0000000022E0 /* Pods-Tests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		000000000E10 /* Cara */ = {
+		000000000E40 /* Cara */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000000E20 /* Build configuration list for PBXNativeTarget "Cara" */;
+			buildConfigurationList = 000000000E50 /* Build configuration list for PBXNativeTarget "Cara" */;
 			buildPhases = (
-				000000000E60 /* Headers */,
-				000000000E70 /* Sources */,
-				000000000E80 /* Frameworks */,
-				000000000E90 /* Resources */,
+				000000000E90 /* Headers */,
+				000000000EA0 /* Sources */,
+				000000000EB0 /* Frameworks */,
+				000000000EC0 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				000000002350 /* PBXTargetDependency */,
+				0000000023B0 /* PBXTargetDependency */,
 			);
 			name = Cara;
 			productName = Cara;
-			productReference = 000000000E50 /* Cara.framework */;
+			productReference = 000000000E80 /* Cara.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000001030 /* CryptoSwift */ = {
+		000000001090 /* CryptoSwift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000001040 /* Build configuration list for PBXNativeTarget "CryptoSwift" */;
+			buildConfigurationList = 0000000010A0 /* Build configuration list for PBXNativeTarget "CryptoSwift" */;
 			buildPhases = (
-				000000001080 /* Headers */,
-				000000001090 /* Sources */,
-				0000000010A0 /* Frameworks */,
-				0000000010B0 /* Resources */,
+				0000000010E0 /* Headers */,
+				0000000010F0 /* Sources */,
+				000000001100 /* Frameworks */,
+				000000001110 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1238,36 +1244,36 @@
 			);
 			name = CryptoSwift;
 			productName = CryptoSwift;
-			productReference = 000000001070 /* CryptoSwift.framework */;
+			productReference = 0000000010D0 /* CryptoSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000001600 /* Mockingjay */ = {
+		000000001660 /* Mockingjay */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000001610 /* Build configuration list for PBXNativeTarget "Mockingjay" */;
+			buildConfigurationList = 000000001670 /* Build configuration list for PBXNativeTarget "Mockingjay" */;
 			buildPhases = (
-				000000001650 /* Headers */,
-				000000001660 /* Sources */,
-				000000001670 /* Frameworks */,
-				000000001680 /* Resources */,
+				0000000016B0 /* Headers */,
+				0000000016C0 /* Sources */,
+				0000000016D0 /* Frameworks */,
+				0000000016E0 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				0000000023D0 /* PBXTargetDependency */,
+				000000002430 /* PBXTargetDependency */,
 			);
 			name = Mockingjay;
 			productName = Mockingjay;
-			productReference = 000000001640 /* Mockingjay.framework */;
+			productReference = 0000000016A0 /* Mockingjay.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		0000000017B0 /* Nimble */ = {
+		000000001810 /* Nimble */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0000000017C0 /* Build configuration list for PBXNativeTarget "Nimble" */;
+			buildConfigurationList = 000000001820 /* Build configuration list for PBXNativeTarget "Nimble" */;
 			buildPhases = (
-				000000001800 /* Headers */,
-				000000001810 /* Sources */,
-				000000001820 /* Frameworks */,
-				000000001830 /* Resources */,
+				000000001860 /* Headers */,
+				000000001870 /* Sources */,
+				000000001880 /* Frameworks */,
+				000000001890 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1275,17 +1281,17 @@
 			);
 			name = Nimble;
 			productName = Nimble;
-			productReference = 0000000017F0 /* Nimble.framework */;
+			productReference = 000000001850 /* Nimble.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000001D30 /* Quick */ = {
+		000000001D90 /* Quick */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000001D40 /* Build configuration list for PBXNativeTarget "Quick" */;
+			buildConfigurationList = 000000001DA0 /* Build configuration list for PBXNativeTarget "Quick" */;
 			buildPhases = (
-				000000001D80 /* Headers */,
-				000000001D90 /* Sources */,
-				000000001DA0 /* Frameworks */,
-				000000001DB0 /* Resources */,
+				000000001DE0 /* Headers */,
+				000000001DF0 /* Sources */,
+				000000001E00 /* Frameworks */,
+				000000001E10 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1293,17 +1299,17 @@
 			);
 			name = Quick;
 			productName = Quick;
-			productReference = 000000001D70 /* Quick.framework */;
+			productReference = 000000001DD0 /* Quick.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000002040 /* URITemplate */ = {
+		0000000020A0 /* URITemplate */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000002050 /* Build configuration list for PBXNativeTarget "URITemplate" */;
+			buildConfigurationList = 0000000020B0 /* Build configuration list for PBXNativeTarget "URITemplate" */;
 			buildPhases = (
-				000000002090 /* Headers */,
-				0000000020A0 /* Sources */,
-				0000000020B0 /* Frameworks */,
-				0000000020C0 /* Resources */,
+				0000000020F0 /* Headers */,
+				000000002100 /* Sources */,
+				000000002110 /* Frameworks */,
+				000000002120 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1311,31 +1317,31 @@
 			);
 			name = URITemplate;
 			productName = URITemplate;
-			productReference = 000000002080 /* URITemplate.framework */;
+			productReference = 0000000020E0 /* URITemplate.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000002180 /* Pods-Tests */ = {
+		0000000021E0 /* Pods-Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000002190 /* Build configuration list for PBXNativeTarget "Pods-Tests" */;
+			buildConfigurationList = 0000000021F0 /* Build configuration list for PBXNativeTarget "Pods-Tests" */;
 			buildPhases = (
-				0000000021D0 /* Headers */,
-				0000000021E0 /* Sources */,
-				0000000021F0 /* Frameworks */,
-				000000002200 /* Resources */,
+				000000002230 /* Headers */,
+				000000002240 /* Sources */,
+				000000002250 /* Frameworks */,
+				000000002260 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				000000002330 /* PBXTargetDependency */,
 				000000002390 /* PBXTargetDependency */,
-				0000000023B0 /* PBXTargetDependency */,
+				0000000023F0 /* PBXTargetDependency */,
 				000000002410 /* PBXTargetDependency */,
-				000000002430 /* PBXTargetDependency */,
-				000000002450 /* PBXTargetDependency */,
+				000000002470 /* PBXTargetDependency */,
+				000000002490 /* PBXTargetDependency */,
+				0000000024B0 /* PBXTargetDependency */,
 			);
 			name = "Pods-Tests";
 			productName = "Pods-Tests";
-			productReference = 0000000021C0 /* Pods_Tests.framework */;
+			productReference = 000000002220 /* Pods_Tests.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -1359,61 +1365,61 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				000000000E10 /* Cara */,
-				000000001030 /* CryptoSwift */,
-				000000001600 /* Mockingjay */,
-				0000000017B0 /* Nimble */,
-				000000002180 /* Pods-Tests */,
-				000000001D30 /* Quick */,
-				000000002040 /* URITemplate */,
+				000000000E40 /* Cara */,
+				000000001090 /* CryptoSwift */,
+				000000001660 /* Mockingjay */,
+				000000001810 /* Nimble */,
+				0000000021E0 /* Pods-Tests */,
+				000000001D90 /* Quick */,
+				0000000020A0 /* URITemplate */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		000000000E90 /* Resources */ = {
+		000000000EC0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000010B0 /* Resources */ = {
+		000000001110 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001680 /* Resources */ = {
+		0000000016E0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001830 /* Resources */ = {
+		000000001890 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001DB0 /* Resources */ = {
+		000000001E10 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000020C0 /* Resources */ = {
+		000000002120 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000002200 /* Resources */ = {
+		000000002260 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1423,296 +1429,296 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		000000000E70 /* Sources */ = {
+		000000000EA0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001020 /* Cara-dummy.m in Sources */,
-				9D21FF0021D92A4B006EF131 /* OSLog+Request.swift in Sources */,
-				000000000F40 /* CodableSerializer.swift in Sources */,
-				000000000ED0 /* Configuration.swift in Sources */,
-				000000000EE0 /* Dictionary+Merge.swift in Sources */,
-				000000000F00 /* ConsoleLogger.swift in Sources */,
-				000000000F60 /* NetworkService.swift in Sources */,
-				000000000F70 /* PublicKeyPinningService.swift in Sources */,
-				9D21FF0421D92A70006EF131 /* Logger.swift in Sources */,
-				9D21FF0221D92A5F006EF131 /* Configuration+Logger.swift in Sources */,
-				000000000F10 /* Request+URLRequest.swift in Sources */,
-				000000000F20 /* Request.swift in Sources */,
-				000000000F30 /* RequestMethod.swift in Sources */,
-				000000000F80 /* ResponseError.swift in Sources */,
-				000000000F50 /* Serializer.swift in Sources */,
-				000000000F90 /* Service.swift in Sources */,
-				000000000EF0 /* URLResponse+Error.swift in Sources */,
+				000000001080 /* Cara-dummy.m in Sources */,
+				000000000FA0 /* CodableSerializer.swift in Sources */,
+				000000000F30 /* Configuration+Logger.swift in Sources */,
+				000000000F00 /* Configuration.swift in Sources */,
+				000000000F40 /* ConsoleLogger.swift in Sources */,
+				000000000F10 /* Dictionary+Merge.swift in Sources */,
+				000000000F50 /* Logger.swift in Sources */,
+				000000000FC0 /* NetworkService.swift in Sources */,
+				000000000F60 /* OSLog+Request.swift in Sources */,
+				000000000FD0 /* PublicKeyPinningService.swift in Sources */,
+				000000000F70 /* Request+URLRequest.swift in Sources */,
+				000000000F80 /* Request.swift in Sources */,
+				000000000F90 /* RequestMethod.swift in Sources */,
+				000000000FE0 /* ResponseError.swift in Sources */,
+				000000000FB0 /* Serializer.swift in Sources */,
+				000000000FF0 /* Service.swift in Sources */,
+				000000000F20 /* URLResponse+Error.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001090 /* Sources */ = {
+		0000000010F0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000010D0 /* AEAD.swift in Sources */,
-				0000000010E0 /* AEADChaCha20Poly1305.swift in Sources */,
-				0000000012F0 /* AES+Foundation.swift in Sources */,
-				0000000010F0 /* AES.Cryptors.swift in Sources */,
-				000000001100 /* AES.swift in Sources */,
-				000000001110 /* Array+Extension.swift in Sources */,
-				000000001300 /* Array+Foundation.swift in Sources */,
-				000000001120 /* Authenticator.swift in Sources */,
-				000000001130 /* BatchedCollection.swift in Sources */,
-				000000001140 /* Bit.swift in Sources */,
-				000000001150 /* BlockCipher.swift in Sources */,
-				000000001160 /* BlockDecryptor.swift in Sources */,
-				000000001170 /* BlockEncryptor.swift in Sources */,
-				000000001180 /* BlockMode.swift in Sources */,
-				000000001190 /* BlockModeOptions.swift in Sources */,
-				000000001310 /* Blowfish+Foundation.swift in Sources */,
-				000000001230 /* Blowfish.swift in Sources */,
-				0000000011A0 /* CBC.swift in Sources */,
-				000000001240 /* CBCMAC.swift in Sources */,
-				0000000011B0 /* CCM.swift in Sources */,
-				0000000011C0 /* CFB.swift in Sources */,
-				000000001320 /* ChaCha20+Foundation.swift in Sources */,
-				000000001250 /* ChaCha20.swift in Sources */,
-				000000001260 /* Checksum.swift in Sources */,
-				000000001270 /* Cipher.swift in Sources */,
-				0000000011D0 /* CipherModeWorker.swift in Sources */,
-				000000001280 /* CMAC.swift in Sources */,
-				000000001290 /* Collection+Extension.swift in Sources */,
-				0000000012A0 /* CompactMap.swift in Sources */,
-				0000000012B0 /* Cryptor.swift in Sources */,
-				0000000012C0 /* Cryptors.swift in Sources */,
-				0000000015F0 /* CryptoSwift-dummy.m in Sources */,
-				0000000011E0 /* CTR.swift in Sources */,
-				000000001330 /* Data+Extension.swift in Sources */,
-				0000000012D0 /* Digest.swift in Sources */,
-				0000000012E0 /* DigestType.swift in Sources */,
-				0000000011F0 /* ECB.swift in Sources */,
-				000000001200 /* GCM.swift in Sources */,
-				000000001380 /* Generics.swift in Sources */,
-				000000001390 /* HKDF.swift in Sources */,
-				000000001340 /* HMAC+Foundation.swift in Sources */,
-				0000000013A0 /* HMAC.swift in Sources */,
-				0000000013B0 /* Int+Extension.swift in Sources */,
-				0000000013C0 /* MD5.swift in Sources */,
-				0000000013D0 /* NoPadding.swift in Sources */,
-				000000001210 /* OFB.swift in Sources */,
-				0000000013E0 /* Operators.swift in Sources */,
-				0000000013F0 /* Padding.swift in Sources */,
-				000000001400 /* PBKDF1.swift in Sources */,
-				000000001410 /* PBKDF2.swift in Sources */,
-				000000001220 /* PCBC.swift in Sources */,
-				000000001420 /* PKCS5.swift in Sources */,
-				000000001430 /* PKCS7.swift in Sources */,
-				000000001440 /* PKCS7Padding.swift in Sources */,
-				000000001450 /* Poly1305.swift in Sources */,
-				000000001350 /* Rabbit+Foundation.swift in Sources */,
-				000000001460 /* Rabbit.swift in Sources */,
-				000000001470 /* RandomBytesSequence.swift in Sources */,
-				000000001480 /* SecureBytes.swift in Sources */,
-				000000001490 /* SHA1.swift in Sources */,
-				0000000014A0 /* SHA2.swift in Sources */,
-				0000000014B0 /* SHA3.swift in Sources */,
-				0000000014C0 /* StreamDecryptor.swift in Sources */,
-				0000000014D0 /* StreamEncryptor.swift in Sources */,
-				0000000014E0 /* String+Extension.swift in Sources */,
-				000000001360 /* String+FoundationExtension.swift in Sources */,
-				0000000014F0 /* UInt128.swift in Sources */,
-				000000001500 /* UInt16+Extension.swift in Sources */,
-				000000001510 /* UInt32+Extension.swift in Sources */,
-				000000001520 /* UInt64+Extension.swift in Sources */,
-				000000001530 /* UInt8+Extension.swift in Sources */,
-				000000001540 /* Updatable.swift in Sources */,
-				000000001370 /* Utils+Foundation.swift in Sources */,
-				000000001550 /* Utils.swift in Sources */,
-				000000001560 /* ZeroPadding.swift in Sources */,
+				000000001130 /* AEAD.swift in Sources */,
+				000000001140 /* AEADChaCha20Poly1305.swift in Sources */,
+				000000001350 /* AES+Foundation.swift in Sources */,
+				000000001150 /* AES.Cryptors.swift in Sources */,
+				000000001160 /* AES.swift in Sources */,
+				000000001170 /* Array+Extension.swift in Sources */,
+				000000001360 /* Array+Foundation.swift in Sources */,
+				000000001180 /* Authenticator.swift in Sources */,
+				000000001190 /* BatchedCollection.swift in Sources */,
+				0000000011A0 /* Bit.swift in Sources */,
+				0000000011B0 /* BlockCipher.swift in Sources */,
+				0000000011C0 /* BlockDecryptor.swift in Sources */,
+				0000000011D0 /* BlockEncryptor.swift in Sources */,
+				0000000011E0 /* BlockMode.swift in Sources */,
+				0000000011F0 /* BlockModeOptions.swift in Sources */,
+				000000001370 /* Blowfish+Foundation.swift in Sources */,
+				000000001290 /* Blowfish.swift in Sources */,
+				000000001200 /* CBC.swift in Sources */,
+				0000000012A0 /* CBCMAC.swift in Sources */,
+				000000001210 /* CCM.swift in Sources */,
+				000000001220 /* CFB.swift in Sources */,
+				000000001380 /* ChaCha20+Foundation.swift in Sources */,
+				0000000012B0 /* ChaCha20.swift in Sources */,
+				0000000012C0 /* Checksum.swift in Sources */,
+				0000000012D0 /* Cipher.swift in Sources */,
+				000000001230 /* CipherModeWorker.swift in Sources */,
+				0000000012E0 /* CMAC.swift in Sources */,
+				0000000012F0 /* Collection+Extension.swift in Sources */,
+				000000001300 /* CompactMap.swift in Sources */,
+				000000001310 /* Cryptor.swift in Sources */,
+				000000001320 /* Cryptors.swift in Sources */,
+				000000001650 /* CryptoSwift-dummy.m in Sources */,
+				000000001240 /* CTR.swift in Sources */,
+				000000001390 /* Data+Extension.swift in Sources */,
+				000000001330 /* Digest.swift in Sources */,
+				000000001340 /* DigestType.swift in Sources */,
+				000000001250 /* ECB.swift in Sources */,
+				000000001260 /* GCM.swift in Sources */,
+				0000000013E0 /* Generics.swift in Sources */,
+				0000000013F0 /* HKDF.swift in Sources */,
+				0000000013A0 /* HMAC+Foundation.swift in Sources */,
+				000000001400 /* HMAC.swift in Sources */,
+				000000001410 /* Int+Extension.swift in Sources */,
+				000000001420 /* MD5.swift in Sources */,
+				000000001430 /* NoPadding.swift in Sources */,
+				000000001270 /* OFB.swift in Sources */,
+				000000001440 /* Operators.swift in Sources */,
+				000000001450 /* Padding.swift in Sources */,
+				000000001460 /* PBKDF1.swift in Sources */,
+				000000001470 /* PBKDF2.swift in Sources */,
+				000000001280 /* PCBC.swift in Sources */,
+				000000001480 /* PKCS5.swift in Sources */,
+				000000001490 /* PKCS7.swift in Sources */,
+				0000000014A0 /* PKCS7Padding.swift in Sources */,
+				0000000014B0 /* Poly1305.swift in Sources */,
+				0000000013B0 /* Rabbit+Foundation.swift in Sources */,
+				0000000014C0 /* Rabbit.swift in Sources */,
+				0000000014D0 /* RandomBytesSequence.swift in Sources */,
+				0000000014E0 /* SecureBytes.swift in Sources */,
+				0000000014F0 /* SHA1.swift in Sources */,
+				000000001500 /* SHA2.swift in Sources */,
+				000000001510 /* SHA3.swift in Sources */,
+				000000001520 /* StreamDecryptor.swift in Sources */,
+				000000001530 /* StreamEncryptor.swift in Sources */,
+				000000001540 /* String+Extension.swift in Sources */,
+				0000000013C0 /* String+FoundationExtension.swift in Sources */,
+				000000001550 /* UInt128.swift in Sources */,
+				000000001560 /* UInt16+Extension.swift in Sources */,
+				000000001570 /* UInt32+Extension.swift in Sources */,
+				000000001580 /* UInt64+Extension.swift in Sources */,
+				000000001590 /* UInt8+Extension.swift in Sources */,
+				0000000015A0 /* Updatable.swift in Sources */,
+				0000000013D0 /* Utils+Foundation.swift in Sources */,
+				0000000015B0 /* Utils.swift in Sources */,
+				0000000015C0 /* ZeroPadding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001660 /* Sources */ = {
+		0000000016C0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000016C0 /* Builders.swift in Sources */,
-				0000000016D0 /* Matchers.swift in Sources */,
-				0000000017A0 /* Mockingjay-dummy.m in Sources */,
-				0000000016A0 /* Mockingjay.swift in Sources */,
-				0000000016B0 /* MockingjayProtocol.swift in Sources */,
-				0000000016F0 /* MockingjayURLSessionConfiguration.m in Sources */,
-				0000000016E0 /* NSURLSessionConfiguration.swift in Sources */,
-				000000001710 /* XCTest.swift in Sources */,
+				000000001720 /* Builders.swift in Sources */,
+				000000001730 /* Matchers.swift in Sources */,
+				000000001800 /* Mockingjay-dummy.m in Sources */,
+				000000001700 /* Mockingjay.swift in Sources */,
+				000000001710 /* MockingjayProtocol.swift in Sources */,
+				000000001750 /* MockingjayURLSessionConfiguration.m in Sources */,
+				000000001740 /* NSURLSessionConfiguration.swift in Sources */,
+				000000001770 /* XCTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001810 /* Sources */ = {
+		000000001870 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001850 /* AdapterProtocols.swift in Sources */,
-				000000001920 /* AllPass.swift in Sources */,
-				000000001860 /* AssertionDispatcher.swift in Sources */,
-				000000001870 /* AssertionRecorder.swift in Sources */,
-				000000001930 /* Async.swift in Sources */,
-				000000001B20 /* Await.swift in Sources */,
-				000000001940 /* BeAKindOf.swift in Sources */,
-				000000001950 /* BeAnInstanceOf.swift in Sources */,
-				000000001960 /* BeCloseTo.swift in Sources */,
-				000000001970 /* BeEmpty.swift in Sources */,
-				000000001980 /* BeginWith.swift in Sources */,
-				000000001990 /* BeGreaterThan.swift in Sources */,
-				0000000019A0 /* BeGreaterThanOrEqualTo.swift in Sources */,
-				0000000019B0 /* BeIdenticalTo.swift in Sources */,
-				0000000019C0 /* BeLessThan.swift in Sources */,
-				0000000019D0 /* BeLessThanOrEqual.swift in Sources */,
-				0000000019E0 /* BeLogical.swift in Sources */,
-				0000000019F0 /* BeNil.swift in Sources */,
-				000000001A00 /* BeVoid.swift in Sources */,
-				000000001A10 /* Contain.swift in Sources */,
-				000000001A20 /* ContainElementSatisfying.swift in Sources */,
-				000000001BF0 /* CwlBadInstructionException.swift in Sources */,
-				000000001C00 /* CwlCatchBadInstruction.swift in Sources */,
-				000000001BC0 /* CwlCatchException.m in Sources */,
-				000000001BB0 /* CwlCatchException.swift in Sources */,
-				000000001C10 /* CwlDarwinDefinitions.swift in Sources */,
-				000000001BD0 /* CwlMachBadInstructionHandler.m in Sources */,
-				0000000018C0 /* DSL+Wait.swift in Sources */,
-				000000001B70 /* DSL.m in Sources */,
-				0000000018D0 /* DSL.swift in Sources */,
-				000000001A30 /* EndWith.swift in Sources */,
-				000000001A40 /* Equal.swift in Sources */,
-				000000001B30 /* Errors.swift in Sources */,
-				0000000018E0 /* Expectation.swift in Sources */,
-				0000000018F0 /* ExpectationMessage.swift in Sources */,
-				000000001900 /* Expression.swift in Sources */,
-				000000001910 /* FailureMessage.swift in Sources */,
-				000000001B40 /* Functional.swift in Sources */,
-				000000001A50 /* HaveCount.swift in Sources */,
-				000000001BE0 /* mach_excServer.c in Sources */,
-				000000001A60 /* Match.swift in Sources */,
-				000000001A70 /* MatcherFunc.swift in Sources */,
-				000000001A80 /* MatcherProtocols.swift in Sources */,
-				000000001A90 /* MatchError.swift in Sources */,
-				000000001D20 /* Nimble-dummy.m in Sources */,
-				000000001880 /* NimbleEnvironment.swift in Sources */,
-				000000001890 /* NimbleXCTestHandler.swift in Sources */,
-				000000001B80 /* NMBExceptionCapture.m in Sources */,
-				0000000018A0 /* NMBExpectation.swift in Sources */,
-				0000000018B0 /* NMBObjCMatcher.swift in Sources */,
-				000000001B90 /* NMBStringify.m in Sources */,
-				000000001AA0 /* PostNotification.swift in Sources */,
-				000000001AB0 /* Predicate.swift in Sources */,
-				000000001AC0 /* RaisesException.swift in Sources */,
-				000000001AD0 /* SatisfyAllOf.swift in Sources */,
-				000000001AE0 /* SatisfyAnyOf.swift in Sources */,
-				000000001B50 /* SourceLocation.swift in Sources */,
-				000000001B60 /* Stringers.swift in Sources */,
-				000000001AF0 /* ThrowAssertion.swift in Sources */,
-				000000001B00 /* ThrowError.swift in Sources */,
-				000000001B10 /* ToSucceed.swift in Sources */,
-				000000001BA0 /* XCTestObservationCenter+Register.m in Sources */,
+				0000000018B0 /* AdapterProtocols.swift in Sources */,
+				000000001980 /* AllPass.swift in Sources */,
+				0000000018C0 /* AssertionDispatcher.swift in Sources */,
+				0000000018D0 /* AssertionRecorder.swift in Sources */,
+				000000001990 /* Async.swift in Sources */,
+				000000001B80 /* Await.swift in Sources */,
+				0000000019A0 /* BeAKindOf.swift in Sources */,
+				0000000019B0 /* BeAnInstanceOf.swift in Sources */,
+				0000000019C0 /* BeCloseTo.swift in Sources */,
+				0000000019D0 /* BeEmpty.swift in Sources */,
+				0000000019E0 /* BeginWith.swift in Sources */,
+				0000000019F0 /* BeGreaterThan.swift in Sources */,
+				000000001A00 /* BeGreaterThanOrEqualTo.swift in Sources */,
+				000000001A10 /* BeIdenticalTo.swift in Sources */,
+				000000001A20 /* BeLessThan.swift in Sources */,
+				000000001A30 /* BeLessThanOrEqual.swift in Sources */,
+				000000001A40 /* BeLogical.swift in Sources */,
+				000000001A50 /* BeNil.swift in Sources */,
+				000000001A60 /* BeVoid.swift in Sources */,
+				000000001A70 /* Contain.swift in Sources */,
+				000000001A80 /* ContainElementSatisfying.swift in Sources */,
+				000000001C50 /* CwlBadInstructionException.swift in Sources */,
+				000000001C60 /* CwlCatchBadInstruction.swift in Sources */,
+				000000001C20 /* CwlCatchException.m in Sources */,
+				000000001C10 /* CwlCatchException.swift in Sources */,
+				000000001C70 /* CwlDarwinDefinitions.swift in Sources */,
+				000000001C30 /* CwlMachBadInstructionHandler.m in Sources */,
+				000000001920 /* DSL+Wait.swift in Sources */,
+				000000001BD0 /* DSL.m in Sources */,
+				000000001930 /* DSL.swift in Sources */,
+				000000001A90 /* EndWith.swift in Sources */,
+				000000001AA0 /* Equal.swift in Sources */,
+				000000001B90 /* Errors.swift in Sources */,
+				000000001940 /* Expectation.swift in Sources */,
+				000000001950 /* ExpectationMessage.swift in Sources */,
+				000000001960 /* Expression.swift in Sources */,
+				000000001970 /* FailureMessage.swift in Sources */,
+				000000001BA0 /* Functional.swift in Sources */,
+				000000001AB0 /* HaveCount.swift in Sources */,
+				000000001C40 /* mach_excServer.c in Sources */,
+				000000001AC0 /* Match.swift in Sources */,
+				000000001AD0 /* MatcherFunc.swift in Sources */,
+				000000001AE0 /* MatcherProtocols.swift in Sources */,
+				000000001AF0 /* MatchError.swift in Sources */,
+				000000001D80 /* Nimble-dummy.m in Sources */,
+				0000000018E0 /* NimbleEnvironment.swift in Sources */,
+				0000000018F0 /* NimbleXCTestHandler.swift in Sources */,
+				000000001BE0 /* NMBExceptionCapture.m in Sources */,
+				000000001900 /* NMBExpectation.swift in Sources */,
+				000000001910 /* NMBObjCMatcher.swift in Sources */,
+				000000001BF0 /* NMBStringify.m in Sources */,
+				000000001B00 /* PostNotification.swift in Sources */,
+				000000001B10 /* Predicate.swift in Sources */,
+				000000001B20 /* RaisesException.swift in Sources */,
+				000000001B30 /* SatisfyAllOf.swift in Sources */,
+				000000001B40 /* SatisfyAnyOf.swift in Sources */,
+				000000001BB0 /* SourceLocation.swift in Sources */,
+				000000001BC0 /* Stringers.swift in Sources */,
+				000000001B50 /* ThrowAssertion.swift in Sources */,
+				000000001B60 /* ThrowError.swift in Sources */,
+				000000001B70 /* ToSucceed.swift in Sources */,
+				000000001C00 /* XCTestObservationCenter+Register.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001D90 /* Sources */ = {
+		000000001DF0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001DD0 /* Behavior.swift in Sources */,
-				000000001DE0 /* Callsite.swift in Sources */,
-				000000001E70 /* Closures.swift in Sources */,
-				000000001DF0 /* Configuration.swift in Sources */,
-				000000001E00 /* DSL.swift in Sources */,
-				000000001E20 /* ErrorUtility.swift in Sources */,
-				000000001E30 /* Example.swift in Sources */,
-				000000001E40 /* ExampleGroup.swift in Sources */,
-				000000001E80 /* ExampleHooks.swift in Sources */,
-				000000001E50 /* ExampleMetadata.swift in Sources */,
-				000000001E60 /* Filter.swift in Sources */,
-				000000001E90 /* HooksPhase.swift in Sources */,
-				000000001EB0 /* NSBundle+CurrentTestBundle.swift in Sources */,
-				000000001EC0 /* NSString+C99ExtendedIdentifier.swift in Sources */,
-				000000001F20 /* QCKDSL.m in Sources */,
-				000000002030 /* Quick-dummy.m in Sources */,
-				000000001F10 /* QuickConfiguration.m in Sources */,
-				000000001ED0 /* QuickSelectedTestSuiteBuilder.swift in Sources */,
-				000000001F30 /* QuickSpec.m in Sources */,
-				000000001F50 /* QuickSpecBase.m in Sources */,
-				000000001EE0 /* QuickTestSuite.swift in Sources */,
-				000000001EA0 /* SuiteHooks.swift in Sources */,
-				000000001EF0 /* URL+FileName.swift in Sources */,
-				000000001E10 /* World+DSL.swift in Sources */,
-				000000001F00 /* World.swift in Sources */,
-				000000001F40 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
+				000000001E30 /* Behavior.swift in Sources */,
+				000000001E40 /* Callsite.swift in Sources */,
+				000000001ED0 /* Closures.swift in Sources */,
+				000000001E50 /* Configuration.swift in Sources */,
+				000000001E60 /* DSL.swift in Sources */,
+				000000001E80 /* ErrorUtility.swift in Sources */,
+				000000001E90 /* Example.swift in Sources */,
+				000000001EA0 /* ExampleGroup.swift in Sources */,
+				000000001EE0 /* ExampleHooks.swift in Sources */,
+				000000001EB0 /* ExampleMetadata.swift in Sources */,
+				000000001EC0 /* Filter.swift in Sources */,
+				000000001EF0 /* HooksPhase.swift in Sources */,
+				000000001F10 /* NSBundle+CurrentTestBundle.swift in Sources */,
+				000000001F20 /* NSString+C99ExtendedIdentifier.swift in Sources */,
+				000000001F80 /* QCKDSL.m in Sources */,
+				000000002090 /* Quick-dummy.m in Sources */,
+				000000001F70 /* QuickConfiguration.m in Sources */,
+				000000001F30 /* QuickSelectedTestSuiteBuilder.swift in Sources */,
+				000000001F90 /* QuickSpec.m in Sources */,
+				000000001FB0 /* QuickSpecBase.m in Sources */,
+				000000001F40 /* QuickTestSuite.swift in Sources */,
+				000000001F00 /* SuiteHooks.swift in Sources */,
+				000000001F50 /* URL+FileName.swift in Sources */,
+				000000001E70 /* World+DSL.swift in Sources */,
+				000000001F60 /* World.swift in Sources */,
+				000000001FA0 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000020A0 /* Sources */ = {
+		000000002100 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000002170 /* URITemplate-dummy.m in Sources */,
-				0000000020E0 /* URITemplate.swift in Sources */,
+				0000000021D0 /* URITemplate-dummy.m in Sources */,
+				000000002140 /* URITemplate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000021E0 /* Sources */ = {
+		000000002240 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000022E0 /* Pods-Tests-dummy.m in Sources */,
+				000000002340 /* Pods-Tests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		000000002330 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Cara;
-			target = 000000000E10 /* Cara */;
-			targetProxy = 000000002320 /* PBXContainerItemProxy */;
-		};
-		000000002350 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CryptoSwift;
-			target = 000000001030 /* CryptoSwift */;
-			targetProxy = 000000002340 /* PBXContainerItemProxy */;
-		};
 		000000002390 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = CryptoSwift;
-			target = 000000001030 /* CryptoSwift */;
+			name = Cara;
+			target = 000000000E40 /* Cara */;
 			targetProxy = 000000002380 /* PBXContainerItemProxy */;
 		};
 		0000000023B0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Mockingjay;
-			target = 000000001600 /* Mockingjay */;
+			name = CryptoSwift;
+			target = 000000001090 /* CryptoSwift */;
 			targetProxy = 0000000023A0 /* PBXContainerItemProxy */;
 		};
-		0000000023D0 /* PBXTargetDependency */ = {
+		0000000023F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = URITemplate;
-			target = 000000002040 /* URITemplate */;
-			targetProxy = 0000000023C0 /* PBXContainerItemProxy */;
+			name = CryptoSwift;
+			target = 000000001090 /* CryptoSwift */;
+			targetProxy = 0000000023E0 /* PBXContainerItemProxy */;
 		};
 		000000002410 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Nimble;
-			target = 0000000017B0 /* Nimble */;
+			name = Mockingjay;
+			target = 000000001660 /* Mockingjay */;
 			targetProxy = 000000002400 /* PBXContainerItemProxy */;
 		};
 		000000002430 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Quick;
-			target = 000000001D30 /* Quick */;
+			name = URITemplate;
+			target = 0000000020A0 /* URITemplate */;
 			targetProxy = 000000002420 /* PBXContainerItemProxy */;
 		};
-		000000002450 /* PBXTargetDependency */ = {
+		000000002470 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Nimble;
+			target = 000000001810 /* Nimble */;
+			targetProxy = 000000002460 /* PBXContainerItemProxy */;
+		};
+		000000002490 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Quick;
+			target = 000000001D90 /* Quick */;
+			targetProxy = 000000002480 /* PBXContainerItemProxy */;
+		};
+		0000000024B0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = URITemplate;
-			target = 000000002040 /* URITemplate */;
-			targetProxy = 000000002440 /* PBXContainerItemProxy */;
+			target = 0000000020A0 /* URITemplate */;
+			targetProxy = 0000000024A0 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1838,15 +1844,16 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 4.2;
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Release;
 		};
-		000000000E30 /* Release */ = {
+		000000000E60 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000000FB0 /* Cara.xcconfig */;
+			baseConfigurationReference = 000000001010 /* Cara.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -1879,9 +1886,9 @@
 			};
 			name = Release;
 		};
-		000000000E40 /* Debug */ = {
+		000000000E70 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000000FB0 /* Cara.xcconfig */;
+			baseConfigurationReference = 000000001010 /* Cara.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -1913,9 +1920,9 @@
 			};
 			name = Debug;
 		};
-		000000001050 /* Release */ = {
+		0000000010B0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001580 /* CryptoSwift.xcconfig */;
+			baseConfigurationReference = 0000000015E0 /* CryptoSwift.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -1947,9 +1954,9 @@
 			};
 			name = Release;
 		};
-		000000001060 /* Debug */ = {
+		0000000010C0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001580 /* CryptoSwift.xcconfig */;
+			baseConfigurationReference = 0000000015E0 /* CryptoSwift.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -1980,9 +1987,9 @@
 			};
 			name = Debug;
 		};
-		000000001620 /* Release */ = {
+		000000001680 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001730 /* Mockingjay.xcconfig */;
+			baseConfigurationReference = 000000001790 /* Mockingjay.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2014,9 +2021,9 @@
 			};
 			name = Release;
 		};
-		000000001630 /* Debug */ = {
+		000000001690 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001730 /* Mockingjay.xcconfig */;
+			baseConfigurationReference = 000000001790 /* Mockingjay.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2047,9 +2054,9 @@
 			};
 			name = Debug;
 		};
-		0000000017D0 /* Release */ = {
+		000000001830 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001CB0 /* Nimble.xcconfig */;
+			baseConfigurationReference = 000000001D10 /* Nimble.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2081,9 +2088,9 @@
 			};
 			name = Release;
 		};
-		0000000017E0 /* Debug */ = {
+		000000001840 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001CB0 /* Nimble.xcconfig */;
+			baseConfigurationReference = 000000001D10 /* Nimble.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2114,9 +2121,9 @@
 			};
 			name = Debug;
 		};
-		000000001D50 /* Release */ = {
+		000000001DB0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001FC0 /* Quick.xcconfig */;
+			baseConfigurationReference = 000000002020 /* Quick.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2148,9 +2155,9 @@
 			};
 			name = Release;
 		};
-		000000001D60 /* Debug */ = {
+		000000001DC0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001FC0 /* Quick.xcconfig */;
+			baseConfigurationReference = 000000002020 /* Quick.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2181,9 +2188,9 @@
 			};
 			name = Debug;
 		};
-		000000002060 /* Release */ = {
+		0000000020C0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000002100 /* URITemplate.xcconfig */;
+			baseConfigurationReference = 000000002160 /* URITemplate.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2215,9 +2222,9 @@
 			};
 			name = Release;
 		};
-		000000002070 /* Debug */ = {
+		0000000020D0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000002100 /* URITemplate.xcconfig */;
+			baseConfigurationReference = 000000002160 /* URITemplate.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2248,9 +2255,9 @@
 			};
 			name = Debug;
 		};
-		0000000021A0 /* Release */ = {
+		000000002200 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000002230 /* Pods-Tests.release.xcconfig */;
+			baseConfigurationReference = 000000002290 /* Pods-Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -2285,9 +2292,9 @@
 			};
 			name = Release;
 		};
-		0000000021B0 /* Debug */ = {
+		000000002210 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000002240 /* Pods-Tests.debug.xcconfig */;
+			baseConfigurationReference = 0000000022A0 /* Pods-Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -2333,65 +2340,65 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000000E20 /* Build configuration list for PBXNativeTarget "Cara" */ = {
+		000000000E50 /* Build configuration list for PBXNativeTarget "Cara" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000000E40 /* Debug */,
-				000000000E30 /* Release */,
+				000000000E70 /* Debug */,
+				000000000E60 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000001040 /* Build configuration list for PBXNativeTarget "CryptoSwift" */ = {
+		0000000010A0 /* Build configuration list for PBXNativeTarget "CryptoSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000001060 /* Debug */,
-				000000001050 /* Release */,
+				0000000010C0 /* Debug */,
+				0000000010B0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000001610 /* Build configuration list for PBXNativeTarget "Mockingjay" */ = {
+		000000001670 /* Build configuration list for PBXNativeTarget "Mockingjay" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000001630 /* Debug */,
-				000000001620 /* Release */,
+				000000001690 /* Debug */,
+				000000001680 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		0000000017C0 /* Build configuration list for PBXNativeTarget "Nimble" */ = {
+		000000001820 /* Build configuration list for PBXNativeTarget "Nimble" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0000000017E0 /* Debug */,
-				0000000017D0 /* Release */,
+				000000001840 /* Debug */,
+				000000001830 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000001D40 /* Build configuration list for PBXNativeTarget "Quick" */ = {
+		000000001DA0 /* Build configuration list for PBXNativeTarget "Quick" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000001D60 /* Debug */,
-				000000001D50 /* Release */,
+				000000001DC0 /* Debug */,
+				000000001DB0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000002050 /* Build configuration list for PBXNativeTarget "URITemplate" */ = {
+		0000000020B0 /* Build configuration list for PBXNativeTarget "URITemplate" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000002070 /* Debug */,
-				000000002060 /* Release */,
+				0000000020D0 /* Debug */,
+				0000000020C0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000002190 /* Build configuration list for PBXNativeTarget "Pods-Tests" */ = {
+		0000000021F0 /* Build configuration list for PBXNativeTarget "Pods-Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0000000021B0 /* Debug */,
-				0000000021A0 /* Release */,
+				000000002210 /* Debug */,
+				000000002200 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,602 +7,610 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		000000000EA0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000E90 /* Foundation.framework */; };
-		000000000EB0 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000130 /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000EC0 /* Dictionary+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000150 /* Dictionary+Merge.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000ED0 /* URLResponse+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000160 /* URLResponse+Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000EE0 /* Request+URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000180 /* Request+URLRequest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000EF0 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000190 /* Request.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F00 /* RequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001A0 /* RequestMethod.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F10 /* CodableSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001C0 /* CodableSerializer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F20 /* Serializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001D0 /* Serializer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F30 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001F0 /* NetworkService.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F40 /* PublicKeyPinningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000200 /* PublicKeyPinningService.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F50 /* ResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000210 /* ResponseError.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000F60 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000220 /* Service.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000000FB0 /* Cara-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000FA0 /* Cara-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000000FF0 /* Cara-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000FE0 /* Cara-dummy.m */; };
-		000000001090 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000E90 /* Foundation.framework */; };
-		0000000010A0 /* AEAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000230 /* AEAD.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000010B0 /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000240 /* AEADChaCha20Poly1305.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000010C0 /* AES.Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000250 /* AES.Cryptors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000010D0 /* AES.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000260 /* AES.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000010E0 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000270 /* Array+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000010F0 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000280 /* Authenticator.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001100 /* BatchedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000290 /* BatchedCollection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001110 /* Bit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002A0 /* Bit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001120 /* BlockCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002B0 /* BlockCipher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001130 /* BlockDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002C0 /* BlockDecryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001140 /* BlockEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002D0 /* BlockEncryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001150 /* BlockMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002E0 /* BlockMode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001160 /* BlockModeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002F0 /* BlockModeOptions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001170 /* CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000300 /* CBC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001180 /* CCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000310 /* CCM.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001190 /* CFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000320 /* CFB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011A0 /* CipherModeWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000330 /* CipherModeWorker.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011B0 /* CTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000340 /* CTR.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011C0 /* ECB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000350 /* ECB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011D0 /* GCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000360 /* GCM.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011E0 /* OFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000370 /* OFB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000011F0 /* PCBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000380 /* PCBC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001200 /* Blowfish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000390 /* Blowfish.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001210 /* CBCMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003A0 /* CBCMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001220 /* ChaCha20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003B0 /* ChaCha20.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001230 /* Checksum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003C0 /* Checksum.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001240 /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003D0 /* Cipher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001250 /* CMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003E0 /* CMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001260 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003F0 /* Collection+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001270 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000400 /* CompactMap.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001280 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000410 /* Cryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001290 /* Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000420 /* Cryptors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012A0 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000430 /* Digest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012B0 /* DigestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000440 /* DigestType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012C0 /* AES+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000450 /* AES+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012D0 /* Array+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000460 /* Array+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012E0 /* Blowfish+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000470 /* Blowfish+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000012F0 /* ChaCha20+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000480 /* ChaCha20+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001300 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000490 /* Data+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001310 /* HMAC+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004A0 /* HMAC+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001320 /* Rabbit+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004B0 /* Rabbit+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001330 /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004C0 /* String+FoundationExtension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001340 /* Utils+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004D0 /* Utils+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001350 /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004E0 /* Generics.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001360 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004F0 /* HKDF.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001370 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000500 /* HMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001380 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000510 /* Int+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001390 /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000520 /* MD5.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013A0 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000530 /* NoPadding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013B0 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000540 /* Operators.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013C0 /* Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000550 /* Padding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013D0 /* PBKDF1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000560 /* PBKDF1.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013E0 /* PBKDF2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000570 /* PBKDF2.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000013F0 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000580 /* PKCS5.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001400 /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000590 /* PKCS7.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001410 /* PKCS7Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005A0 /* PKCS7Padding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001420 /* Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005B0 /* Poly1305.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001430 /* Rabbit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005C0 /* Rabbit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001440 /* RandomBytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005D0 /* RandomBytesSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001450 /* SecureBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005E0 /* SecureBytes.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001460 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005F0 /* SHA1.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001470 /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000600 /* SHA2.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001480 /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000610 /* SHA3.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001490 /* StreamDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000620 /* StreamDecryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014A0 /* StreamEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000630 /* StreamEncryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014B0 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000640 /* String+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014C0 /* UInt128.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000650 /* UInt128.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014D0 /* UInt16+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000660 /* UInt16+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014E0 /* UInt32+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000670 /* UInt32+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000014F0 /* UInt64+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000680 /* UInt64+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001500 /* UInt8+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000690 /* UInt8+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001510 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006A0 /* Updatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001520 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006B0 /* Utils.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001530 /* ZeroPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006C0 /* ZeroPadding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001580 /* CryptoSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001570 /* CryptoSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0000000015C0 /* CryptoSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000000015B0 /* CryptoSwift-dummy.m */; };
-		000000001660 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000E90 /* Foundation.framework */; };
-		000000001670 /* Mockingjay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006F0 /* Mockingjay.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001680 /* MockingjayProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000700 /* MockingjayProtocol.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001690 /* Builders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000710 /* Builders.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000016A0 /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000720 /* Matchers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000016B0 /* NSURLSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000730 /* NSURLSessionConfiguration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000016C0 /* MockingjayURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000740 /* MockingjayURLSessionConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000016D0 /* Mockingjay.h in Headers */ = {isa = PBXBuildFile; fileRef = 0000000006E0 /* Mockingjay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0000000016E0 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000760 /* XCTest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001730 /* Mockingjay-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001720 /* Mockingjay-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001770 /* Mockingjay-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001760 /* Mockingjay-dummy.m */; };
-		000000001810 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000E90 /* Foundation.framework */; };
-		000000001820 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000770 /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001830 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000780 /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001840 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000790 /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001850 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007A0 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001860 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007B0 /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001870 /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007C0 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001880 /* NMBObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007D0 /* NMBObjCMatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001890 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007E0 /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018A0 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007F0 /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018B0 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000800 /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018C0 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000810 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018D0 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000820 /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018E0 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000830 /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000018F0 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000840 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001900 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000850 /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001910 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000860 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001920 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000870 /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001930 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000880 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001940 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000890 /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001950 /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008A0 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001960 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008B0 /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001970 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008C0 /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001980 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008D0 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001990 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008E0 /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019A0 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008F0 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019B0 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000900 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019C0 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000910 /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019D0 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000920 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019E0 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000930 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0000000019F0 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000940 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A00 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000950 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A10 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000960 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A20 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000970 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A30 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000980 /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A40 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000990 /* MatcherFunc.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A50 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009A0 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A60 /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009B0 /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A70 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009C0 /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A80 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009D0 /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001A90 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009E0 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AA0 /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009F0 /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AB0 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A00 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AC0 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A10 /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AD0 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A20 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AE0 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A30 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001AF0 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A50 /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B00 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A60 /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B10 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A70 /* Functional.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B20 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A80 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B30 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A90 /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B40 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AB0 /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B50 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AD0 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B60 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AF0 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B70 /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B00 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B80 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B10 /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001B90 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B20 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BA0 /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B40 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BB0 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B60 /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BC0 /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B80 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BD0 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B90 /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BE0 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BA0 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001BF0 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000A40 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C00 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000AA0 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C10 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000AC0 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C20 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000AE0 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C30 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B30 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C40 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B50 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C50 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B70 /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001C60 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000BB0 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001CB0 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001CA0 /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001CF0 /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001CE0 /* Nimble-dummy.m */; };
-		000000001D90 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000E90 /* Foundation.framework */; };
-		000000001DA0 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BC0 /* Behavior.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001DB0 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BD0 /* Callsite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001DC0 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BE0 /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001DD0 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BF0 /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001DE0 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C00 /* World+DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001DF0 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C10 /* ErrorUtility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E00 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C20 /* Example.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E10 /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C30 /* ExampleGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E20 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C40 /* ExampleMetadata.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E30 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C50 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E40 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C60 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E50 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C70 /* ExampleHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E60 /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C80 /* HooksPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E70 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C90 /* SuiteHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E80 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CA0 /* NSBundle+CurrentTestBundle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001E90 /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CB0 /* NSString+C99ExtendedIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EA0 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CC0 /* QuickSelectedTestSuiteBuilder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EB0 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CD0 /* QuickTestSuite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EC0 /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CE0 /* URL+FileName.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001ED0 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CF0 /* World.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EE0 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D10 /* QuickConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001EF0 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D30 /* QCKDSL.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F00 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D60 /* QuickSpec.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F10 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D70 /* XCTestSuite+QuickTestSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F20 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D90 /* QuickSpecBase.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000001F30 /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D00 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001F40 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D20 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001F50 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D40 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001F60 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D50 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000001F70 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D80 /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		000000001FC0 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001FB0 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000002000 /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001FF0 /* Quick-dummy.m */; };
-		0000000020A0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000E90 /* Foundation.framework */; };
-		0000000020B0 /* URITemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000DA0 /* URITemplate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		000000002100 /* URITemplate-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0000000020F0 /* URITemplate-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		000000002140 /* URITemplate-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000002130 /* URITemplate-dummy.m */; };
-		0000000021E0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000E90 /* Foundation.framework */; };
-		000000002250 /* Pods-Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000002240 /* Pods-Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0000000022B0 /* Pods-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000000022A0 /* Pods-Tests-dummy.m */; };
-		0000000022D0 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000022C0 /* XCTest.framework */; };
-		0000000022E0 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000022C0 /* XCTest.framework */; };
-		000000002340 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000002330 /* CryptoSwift.framework */; };
-		0000000023C0 /* URITemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000023B0 /* URITemplate.framework */; };
+		000000000EC0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
+		000000000ED0 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000130 /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000EE0 /* Dictionary+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000150 /* Dictionary+Merge.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000EF0 /* URLResponse+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000160 /* URLResponse+Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F00 /* ConsoleLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000180 /* ConsoleLogger.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F10 /* Request+URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001A0 /* Request+URLRequest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F20 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001B0 /* Request.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F30 /* RequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001C0 /* RequestMethod.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F40 /* CodableSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001E0 /* CodableSerializer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F50 /* Serializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000001F0 /* Serializer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F60 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000210 /* NetworkService.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F70 /* PublicKeyPinningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000220 /* PublicKeyPinningService.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F80 /* ResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000230 /* ResponseError.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000F90 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000240 /* Service.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000000FE0 /* Cara-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000FD0 /* Cara-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001020 /* Cara-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001010 /* Cara-dummy.m */; };
+		0000000010C0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
+		0000000010D0 /* AEAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000250 /* AEAD.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000010E0 /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000260 /* AEADChaCha20Poly1305.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000010F0 /* AES.Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000270 /* AES.Cryptors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001100 /* AES.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000280 /* AES.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001110 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000290 /* Array+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001120 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002A0 /* Authenticator.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001130 /* BatchedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002B0 /* BatchedCollection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001140 /* Bit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002C0 /* Bit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001150 /* BlockCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002D0 /* BlockCipher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001160 /* BlockDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002E0 /* BlockDecryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001170 /* BlockEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000002F0 /* BlockEncryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001180 /* BlockMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000300 /* BlockMode.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001190 /* BlockModeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000310 /* BlockModeOptions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011A0 /* CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000320 /* CBC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011B0 /* CCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000330 /* CCM.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011C0 /* CFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000340 /* CFB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011D0 /* CipherModeWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000350 /* CipherModeWorker.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011E0 /* CTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000360 /* CTR.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000011F0 /* ECB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000370 /* ECB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001200 /* GCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000380 /* GCM.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001210 /* OFB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000390 /* OFB.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001220 /* PCBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003A0 /* PCBC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001230 /* Blowfish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003B0 /* Blowfish.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001240 /* CBCMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003C0 /* CBCMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001250 /* ChaCha20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003D0 /* ChaCha20.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001260 /* Checksum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003E0 /* Checksum.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001270 /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000003F0 /* Cipher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001280 /* CMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000400 /* CMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001290 /* Collection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000410 /* Collection+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012A0 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000420 /* CompactMap.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012B0 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000430 /* Cryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012C0 /* Cryptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000440 /* Cryptors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012D0 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000450 /* Digest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012E0 /* DigestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000460 /* DigestType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000012F0 /* AES+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000470 /* AES+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001300 /* Array+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000480 /* Array+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001310 /* Blowfish+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000490 /* Blowfish+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001320 /* ChaCha20+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004A0 /* ChaCha20+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001330 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004B0 /* Data+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001340 /* HMAC+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004C0 /* HMAC+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001350 /* Rabbit+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004D0 /* Rabbit+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001360 /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004E0 /* String+FoundationExtension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001370 /* Utils+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000004F0 /* Utils+Foundation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001380 /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000500 /* Generics.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001390 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000510 /* HKDF.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013A0 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000520 /* HMAC.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013B0 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000530 /* Int+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013C0 /* MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000540 /* MD5.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013D0 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000550 /* NoPadding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013E0 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000560 /* Operators.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000013F0 /* Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000570 /* Padding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001400 /* PBKDF1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000580 /* PBKDF1.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001410 /* PBKDF2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000590 /* PBKDF2.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001420 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005A0 /* PKCS5.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001430 /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005B0 /* PKCS7.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001440 /* PKCS7Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005C0 /* PKCS7Padding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001450 /* Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005D0 /* Poly1305.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001460 /* Rabbit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005E0 /* Rabbit.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001470 /* RandomBytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000005F0 /* RandomBytesSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001480 /* SecureBytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000600 /* SecureBytes.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001490 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000610 /* SHA1.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014A0 /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000620 /* SHA2.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014B0 /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000630 /* SHA3.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014C0 /* StreamDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000640 /* StreamDecryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014D0 /* StreamEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000650 /* StreamEncryptor.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014E0 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000660 /* String+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000014F0 /* UInt128.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000670 /* UInt128.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001500 /* UInt16+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000680 /* UInt16+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001510 /* UInt32+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000690 /* UInt32+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001520 /* UInt64+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006A0 /* UInt64+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001530 /* UInt8+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006B0 /* UInt8+Extension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001540 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006C0 /* Updatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001550 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006D0 /* Utils.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001560 /* ZeroPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000006E0 /* ZeroPadding.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000015B0 /* CryptoSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0000000015A0 /* CryptoSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0000000015F0 /* CryptoSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000000015E0 /* CryptoSwift-dummy.m */; };
+		000000001690 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
+		0000000016A0 /* Mockingjay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000710 /* Mockingjay.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000016B0 /* MockingjayProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000720 /* MockingjayProtocol.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000016C0 /* Builders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000730 /* Builders.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000016D0 /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000740 /* Matchers.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000016E0 /* NSURLSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000750 /* NSURLSessionConfiguration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000016F0 /* MockingjayURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000760 /* MockingjayURLSessionConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001700 /* Mockingjay.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000700 /* Mockingjay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001710 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000780 /* XCTest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001760 /* Mockingjay-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001750 /* Mockingjay-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0000000017A0 /* Mockingjay-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001790 /* Mockingjay-dummy.m */; };
+		000000001840 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
+		000000001850 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000790 /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001860 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007A0 /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001870 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007B0 /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001880 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007C0 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001890 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007D0 /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018A0 /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007E0 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018B0 /* NMBObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000007F0 /* NMBObjCMatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018C0 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000800 /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018D0 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000810 /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018E0 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000820 /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000018F0 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000830 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001900 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000840 /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001910 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000850 /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001920 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000860 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001930 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000870 /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001940 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000880 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001950 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000890 /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001960 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008A0 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001970 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008B0 /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001980 /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008C0 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001990 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008D0 /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019A0 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008E0 /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019B0 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000008F0 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019C0 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000900 /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019D0 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000910 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019E0 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000920 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0000000019F0 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000930 /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A00 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000940 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A10 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000950 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A20 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000960 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A30 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000970 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A40 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000980 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A50 /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000990 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A60 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009A0 /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A70 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009B0 /* MatcherFunc.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A80 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009C0 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001A90 /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009D0 /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AA0 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009E0 /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AB0 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000009F0 /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AC0 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A00 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AD0 /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A10 /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AE0 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A20 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001AF0 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A30 /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B00 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A40 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B10 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A50 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B20 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A70 /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B30 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A80 /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B40 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000A90 /* Functional.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B50 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AA0 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B60 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AB0 /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B70 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AD0 /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B80 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000AF0 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001B90 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B10 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BA0 /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B20 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BB0 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B30 /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BC0 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B40 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BD0 /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B60 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BE0 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 000000000B80 /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001BF0 /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BA0 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C00 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BB0 /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C10 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BC0 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001C20 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000A60 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001C30 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000AC0 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001C40 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000AE0 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001C50 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B00 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001C60 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B50 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001C70 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B70 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001C80 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000B90 /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001C90 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000BD0 /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001CE0 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001CD0 /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001D20 /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000001D10 /* Nimble-dummy.m */; };
+		000000001DC0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
+		000000001DD0 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BE0 /* Behavior.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001DE0 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000BF0 /* Callsite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001DF0 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C00 /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E00 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C10 /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E10 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C20 /* World+DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E20 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C30 /* ErrorUtility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E30 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C40 /* Example.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E40 /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C50 /* ExampleGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E50 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C60 /* ExampleMetadata.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E60 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C70 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E70 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C80 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E80 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000C90 /* ExampleHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001E90 /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CA0 /* HooksPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EA0 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CB0 /* SuiteHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EB0 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CC0 /* NSBundle+CurrentTestBundle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EC0 /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CD0 /* NSString+C99ExtendedIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001ED0 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CE0 /* QuickSelectedTestSuiteBuilder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EE0 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000CF0 /* QuickTestSuite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001EF0 /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D00 /* URL+FileName.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F00 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D10 /* World.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F10 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D30 /* QuickConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F20 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D50 /* QCKDSL.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F30 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D80 /* QuickSpec.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F40 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000D90 /* XCTestSuite+QuickTestSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F50 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000000DB0 /* QuickSpecBase.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000001F60 /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D20 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001F70 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D40 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001F80 /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D60 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001F90 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000D70 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000001FA0 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000000DA0 /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		000000001FF0 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000001FE0 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000002030 /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000002020 /* Quick-dummy.m */; };
+		0000000020D0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
+		0000000020E0 /* URITemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000DC0 /* URITemplate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		000000002130 /* URITemplate-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000002120 /* URITemplate-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		000000002170 /* URITemplate-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 000000002160 /* URITemplate-dummy.m */; };
+		000000002210 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000EB0 /* Foundation.framework */; };
+		000000002280 /* Pods-Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 000000002270 /* Pods-Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0000000022E0 /* Pods-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000000022D0 /* Pods-Tests-dummy.m */; };
+		000000002300 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000022F0 /* XCTest.framework */; };
+		000000002310 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000022F0 /* XCTest.framework */; };
+		000000002370 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000002360 /* CryptoSwift.framework */; };
+		0000000023F0 /* URITemplate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0000000023E0 /* URITemplate.framework */; };
+		9D21FF0021D92A4B006EF131 /* OSLog+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FEFF21D92A4B006EF131 /* OSLog+Request.swift */; };
+		9D21FF0221D92A5F006EF131 /* Configuration+Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FF0121D92A5F006EF131 /* Configuration+Logger.swift */; };
+		9D21FF0421D92A70006EF131 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D21FF0321D92A70006EF131 /* Logger.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0000000022F0 /* PBXContainerItemProxy */ = {
+		000000002320 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000000DF0;
+			remoteGlobalIDString = 000000000E10;
 			remoteInfo = Cara;
 		};
-		000000002310 /* PBXContainerItemProxy */ = {
+		000000002340 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000001000;
+			remoteGlobalIDString = 000000001030;
 			remoteInfo = CryptoSwift;
 		};
-		000000002350 /* PBXContainerItemProxy */ = {
+		000000002380 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000001000;
+			remoteGlobalIDString = 000000001030;
 			remoteInfo = CryptoSwift;
 		};
-		000000002370 /* PBXContainerItemProxy */ = {
+		0000000023A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 0000000015D0;
+			remoteGlobalIDString = 000000001600;
 			remoteInfo = Mockingjay;
 		};
-		000000002390 /* PBXContainerItemProxy */ = {
+		0000000023C0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000002010;
+			remoteGlobalIDString = 000000002040;
 			remoteInfo = URITemplate;
 		};
-		0000000023D0 /* PBXContainerItemProxy */ = {
+		000000002400 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000001780;
+			remoteGlobalIDString = 0000000017B0;
 			remoteInfo = Nimble;
 		};
-		0000000023F0 /* PBXContainerItemProxy */ = {
+		000000002420 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000001D00;
+			remoteGlobalIDString = 000000001D30;
 			remoteInfo = Quick;
 		};
-		000000002410 /* PBXContainerItemProxy */ = {
+		000000002440 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 000000000000 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 000000002010;
+			remoteGlobalIDString = 000000002040;
 			remoteInfo = URITemplate;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		000000000110 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		000000000110 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		000000000130 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		000000000150 /* Dictionary+Merge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Dictionary+Merge.swift"; sourceTree = "<group>"; };
 		000000000160 /* URLResponse+Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "URLResponse+Error.swift"; sourceTree = "<group>"; };
-		000000000180 /* Request+URLRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+URLRequest.swift"; sourceTree = "<group>"; };
-		000000000190 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
-		0000000001A0 /* RequestMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RequestMethod.swift; sourceTree = "<group>"; };
-		0000000001C0 /* CodableSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodableSerializer.swift; sourceTree = "<group>"; };
-		0000000001D0 /* Serializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Serializer.swift; sourceTree = "<group>"; };
-		0000000001F0 /* NetworkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
-		000000000200 /* PublicKeyPinningService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PublicKeyPinningService.swift; sourceTree = "<group>"; };
-		000000000210 /* ResponseError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResponseError.swift; sourceTree = "<group>"; };
-		000000000220 /* Service.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
-		000000000230 /* AEAD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEAD.swift; path = Sources/CryptoSwift/AEAD/AEAD.swift; sourceTree = "<group>"; };
-		000000000240 /* AEADChaCha20Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEADChaCha20Poly1305.swift; path = Sources/CryptoSwift/AEAD/AEADChaCha20Poly1305.swift; sourceTree = "<group>"; };
-		000000000250 /* AES.Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.Cryptors.swift; path = Sources/CryptoSwift/AES.Cryptors.swift; sourceTree = "<group>"; };
-		000000000260 /* AES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.swift; path = Sources/CryptoSwift/AES.swift; sourceTree = "<group>"; };
-		000000000270 /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "Sources/CryptoSwift/Array+Extension.swift"; sourceTree = "<group>"; };
-		000000000280 /* Authenticator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authenticator.swift; path = Sources/CryptoSwift/Authenticator.swift; sourceTree = "<group>"; };
-		000000000290 /* BatchedCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BatchedCollection.swift; path = Sources/CryptoSwift/BatchedCollection.swift; sourceTree = "<group>"; };
-		0000000002A0 /* Bit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bit.swift; path = Sources/CryptoSwift/Bit.swift; sourceTree = "<group>"; };
-		0000000002B0 /* BlockCipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockCipher.swift; path = Sources/CryptoSwift/BlockCipher.swift; sourceTree = "<group>"; };
-		0000000002C0 /* BlockDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockDecryptor.swift; path = Sources/CryptoSwift/BlockDecryptor.swift; sourceTree = "<group>"; };
-		0000000002D0 /* BlockEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockEncryptor.swift; path = Sources/CryptoSwift/BlockEncryptor.swift; sourceTree = "<group>"; };
-		0000000002E0 /* BlockMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockMode.swift; path = Sources/CryptoSwift/BlockMode/BlockMode.swift; sourceTree = "<group>"; };
-		0000000002F0 /* BlockModeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockModeOptions.swift; path = Sources/CryptoSwift/BlockMode/BlockModeOptions.swift; sourceTree = "<group>"; };
-		000000000300 /* CBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBC.swift; path = Sources/CryptoSwift/BlockMode/CBC.swift; sourceTree = "<group>"; };
-		000000000310 /* CCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CCM.swift; path = Sources/CryptoSwift/BlockMode/CCM.swift; sourceTree = "<group>"; };
-		000000000320 /* CFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CFB.swift; path = Sources/CryptoSwift/BlockMode/CFB.swift; sourceTree = "<group>"; };
-		000000000330 /* CipherModeWorker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CipherModeWorker.swift; path = Sources/CryptoSwift/BlockMode/CipherModeWorker.swift; sourceTree = "<group>"; };
-		000000000340 /* CTR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CTR.swift; path = Sources/CryptoSwift/BlockMode/CTR.swift; sourceTree = "<group>"; };
-		000000000350 /* ECB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ECB.swift; path = Sources/CryptoSwift/BlockMode/ECB.swift; sourceTree = "<group>"; };
-		000000000360 /* GCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCM.swift; path = Sources/CryptoSwift/BlockMode/GCM.swift; sourceTree = "<group>"; };
-		000000000370 /* OFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OFB.swift; path = Sources/CryptoSwift/BlockMode/OFB.swift; sourceTree = "<group>"; };
-		000000000380 /* PCBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PCBC.swift; path = Sources/CryptoSwift/BlockMode/PCBC.swift; sourceTree = "<group>"; };
-		000000000390 /* Blowfish.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Blowfish.swift; path = Sources/CryptoSwift/Blowfish.swift; sourceTree = "<group>"; };
-		0000000003A0 /* CBCMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBCMAC.swift; path = Sources/CryptoSwift/CBCMAC.swift; sourceTree = "<group>"; };
-		0000000003B0 /* ChaCha20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChaCha20.swift; path = Sources/CryptoSwift/ChaCha20.swift; sourceTree = "<group>"; };
-		0000000003C0 /* Checksum.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Checksum.swift; path = Sources/CryptoSwift/Checksum.swift; sourceTree = "<group>"; };
-		0000000003D0 /* Cipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cipher.swift; path = Sources/CryptoSwift/Cipher.swift; sourceTree = "<group>"; };
-		0000000003E0 /* CMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CMAC.swift; path = Sources/CryptoSwift/CMAC.swift; sourceTree = "<group>"; };
-		0000000003F0 /* Collection+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Collection+Extension.swift"; path = "Sources/CryptoSwift/Collection+Extension.swift"; sourceTree = "<group>"; };
-		000000000400 /* CompactMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompactMap.swift; path = Sources/CryptoSwift/CompactMap.swift; sourceTree = "<group>"; };
-		000000000410 /* Cryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptor.swift; path = Sources/CryptoSwift/Cryptor.swift; sourceTree = "<group>"; };
-		000000000420 /* Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptors.swift; path = Sources/CryptoSwift/Cryptors.swift; sourceTree = "<group>"; };
-		000000000430 /* Digest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Digest.swift; path = Sources/CryptoSwift/Digest.swift; sourceTree = "<group>"; };
-		000000000440 /* DigestType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DigestType.swift; path = Sources/CryptoSwift/DigestType.swift; sourceTree = "<group>"; };
-		000000000450 /* AES+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AES+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/AES+Foundation.swift"; sourceTree = "<group>"; };
-		000000000460 /* Array+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Array+Foundation.swift"; sourceTree = "<group>"; };
-		000000000470 /* Blowfish+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Blowfish+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Blowfish+Foundation.swift"; sourceTree = "<group>"; };
-		000000000480 /* ChaCha20+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ChaCha20+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/ChaCha20+Foundation.swift"; sourceTree = "<group>"; };
-		000000000490 /* Data+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extension.swift"; path = "Sources/CryptoSwift/Foundation/Data+Extension.swift"; sourceTree = "<group>"; };
-		0000000004A0 /* HMAC+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HMAC+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/HMAC+Foundation.swift"; sourceTree = "<group>"; };
-		0000000004B0 /* Rabbit+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Rabbit+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Rabbit+Foundation.swift"; sourceTree = "<group>"; };
-		0000000004C0 /* String+FoundationExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+FoundationExtension.swift"; path = "Sources/CryptoSwift/Foundation/String+FoundationExtension.swift"; sourceTree = "<group>"; };
-		0000000004D0 /* Utils+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Utils+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Utils+Foundation.swift"; sourceTree = "<group>"; };
-		0000000004E0 /* Generics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generics.swift; path = Sources/CryptoSwift/Generics.swift; sourceTree = "<group>"; };
-		0000000004F0 /* HKDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HKDF.swift; path = Sources/CryptoSwift/HKDF.swift; sourceTree = "<group>"; };
-		000000000500 /* HMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HMAC.swift; path = Sources/CryptoSwift/HMAC.swift; sourceTree = "<group>"; };
-		000000000510 /* Int+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Int+Extension.swift"; path = "Sources/CryptoSwift/Int+Extension.swift"; sourceTree = "<group>"; };
-		000000000520 /* MD5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MD5.swift; path = Sources/CryptoSwift/MD5.swift; sourceTree = "<group>"; };
-		000000000530 /* NoPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoPadding.swift; path = Sources/CryptoSwift/NoPadding.swift; sourceTree = "<group>"; };
-		000000000540 /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Sources/CryptoSwift/Operators.swift; sourceTree = "<group>"; };
-		000000000550 /* Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Padding.swift; path = Sources/CryptoSwift/Padding.swift; sourceTree = "<group>"; };
-		000000000560 /* PBKDF1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF1.swift; path = Sources/CryptoSwift/PKCS/PBKDF1.swift; sourceTree = "<group>"; };
-		000000000570 /* PBKDF2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF2.swift; path = Sources/CryptoSwift/PKCS/PBKDF2.swift; sourceTree = "<group>"; };
-		000000000580 /* PKCS5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS5.swift; path = Sources/CryptoSwift/PKCS/PKCS5.swift; sourceTree = "<group>"; };
-		000000000590 /* PKCS7.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7.swift; path = Sources/CryptoSwift/PKCS/PKCS7.swift; sourceTree = "<group>"; };
-		0000000005A0 /* PKCS7Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7Padding.swift; path = Sources/CryptoSwift/PKCS/PKCS7Padding.swift; sourceTree = "<group>"; };
-		0000000005B0 /* Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Poly1305.swift; path = Sources/CryptoSwift/Poly1305.swift; sourceTree = "<group>"; };
-		0000000005C0 /* Rabbit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rabbit.swift; path = Sources/CryptoSwift/Rabbit.swift; sourceTree = "<group>"; };
-		0000000005D0 /* RandomBytesSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RandomBytesSequence.swift; path = Sources/CryptoSwift/RandomBytesSequence.swift; sourceTree = "<group>"; };
-		0000000005E0 /* SecureBytes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecureBytes.swift; path = Sources/CryptoSwift/SecureBytes.swift; sourceTree = "<group>"; };
-		0000000005F0 /* SHA1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA1.swift; path = Sources/CryptoSwift/SHA1.swift; sourceTree = "<group>"; };
-		000000000600 /* SHA2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA2.swift; path = Sources/CryptoSwift/SHA2.swift; sourceTree = "<group>"; };
-		000000000610 /* SHA3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA3.swift; path = Sources/CryptoSwift/SHA3.swift; sourceTree = "<group>"; };
-		000000000620 /* StreamDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamDecryptor.swift; path = Sources/CryptoSwift/StreamDecryptor.swift; sourceTree = "<group>"; };
-		000000000630 /* StreamEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamEncryptor.swift; path = Sources/CryptoSwift/StreamEncryptor.swift; sourceTree = "<group>"; };
-		000000000640 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "Sources/CryptoSwift/String+Extension.swift"; sourceTree = "<group>"; };
-		000000000650 /* UInt128.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UInt128.swift; path = Sources/CryptoSwift/UInt128.swift; sourceTree = "<group>"; };
-		000000000660 /* UInt16+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt16+Extension.swift"; path = "Sources/CryptoSwift/UInt16+Extension.swift"; sourceTree = "<group>"; };
-		000000000670 /* UInt32+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt32+Extension.swift"; path = "Sources/CryptoSwift/UInt32+Extension.swift"; sourceTree = "<group>"; };
-		000000000680 /* UInt64+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt64+Extension.swift"; path = "Sources/CryptoSwift/UInt64+Extension.swift"; sourceTree = "<group>"; };
-		000000000690 /* UInt8+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt8+Extension.swift"; path = "Sources/CryptoSwift/UInt8+Extension.swift"; sourceTree = "<group>"; };
-		0000000006A0 /* Updatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Updatable.swift; path = Sources/CryptoSwift/Updatable.swift; sourceTree = "<group>"; };
-		0000000006B0 /* Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = Sources/CryptoSwift/Utils.swift; sourceTree = "<group>"; };
-		0000000006C0 /* ZeroPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ZeroPadding.swift; path = Sources/CryptoSwift/ZeroPadding.swift; sourceTree = "<group>"; };
-		0000000006E0 /* Mockingjay.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Mockingjay.h; path = Sources/Mockingjay/Mockingjay.h; sourceTree = "<group>"; };
-		0000000006F0 /* Mockingjay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Mockingjay.swift; path = Sources/Mockingjay/Mockingjay.swift; sourceTree = "<group>"; };
-		000000000700 /* MockingjayProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockingjayProtocol.swift; path = Sources/Mockingjay/MockingjayProtocol.swift; sourceTree = "<group>"; };
-		000000000710 /* Builders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Builders.swift; path = Sources/Mockingjay/Builders.swift; sourceTree = "<group>"; };
-		000000000720 /* Matchers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Matchers.swift; path = Sources/Mockingjay/Matchers.swift; sourceTree = "<group>"; };
-		000000000730 /* NSURLSessionConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSURLSessionConfiguration.swift; path = Sources/Mockingjay/NSURLSessionConfiguration.swift; sourceTree = "<group>"; };
-		000000000740 /* MockingjayURLSessionConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MockingjayURLSessionConfiguration.m; path = Sources/Mockingjay/MockingjayURLSessionConfiguration.m; sourceTree = "<group>"; };
-		000000000760 /* XCTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCTest.swift; path = Sources/Mockingjay/XCTest.swift; sourceTree = "<group>"; };
-		000000000770 /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
-		000000000780 /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
-		000000000790 /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
-		0000000007A0 /* NimbleEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleEnvironment.swift; path = Sources/Nimble/Adapters/NimbleEnvironment.swift; sourceTree = "<group>"; };
-		0000000007B0 /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
-		0000000007C0 /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
-		0000000007D0 /* NMBObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBObjCMatcher.swift; path = Sources/Nimble/Adapters/NMBObjCMatcher.swift; sourceTree = "<group>"; };
-		0000000007E0 /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
-		0000000007F0 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
-		000000000800 /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
-		000000000810 /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
-		000000000820 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
-		000000000830 /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
-		000000000840 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
-		000000000850 /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Matchers/Async.swift; sourceTree = "<group>"; };
-		000000000860 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
-		000000000870 /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
-		000000000880 /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
-		000000000890 /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
-		0000000008A0 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
-		0000000008B0 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
-		0000000008C0 /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
-		0000000008D0 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
-		0000000008E0 /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
-		0000000008F0 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
-		000000000900 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
-		000000000910 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
-		000000000920 /* BeVoid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeVoid.swift; path = Sources/Nimble/Matchers/BeVoid.swift; sourceTree = "<group>"; };
-		000000000930 /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
-		000000000940 /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
-		000000000950 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
-		000000000960 /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Sources/Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
-		000000000970 /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
-		000000000980 /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
-		000000000990 /* MatcherFunc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherFunc.swift; path = Sources/Nimble/Matchers/MatcherFunc.swift; sourceTree = "<group>"; };
-		0000000009A0 /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
-		0000000009B0 /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
-		0000000009C0 /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
-		0000000009D0 /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
-		0000000009E0 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
-		0000000009F0 /* SatisfyAllOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAllOf.swift; path = Sources/Nimble/Matchers/SatisfyAllOf.swift; sourceTree = "<group>"; };
-		000000000A00 /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
-		000000000A10 /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
-		000000000A20 /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
-		000000000A30 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
-		000000000A40 /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
-		000000000A50 /* Await.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Await.swift; path = Sources/Nimble/Utils/Await.swift; sourceTree = "<group>"; };
-		000000000A60 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
-		000000000A70 /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Sources/Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
-		000000000A80 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
-		000000000A90 /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
-		000000000AA0 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
-		000000000AB0 /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
-		000000000AC0 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
-		000000000AD0 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
-		000000000AE0 /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
-		000000000AF0 /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
-		000000000B00 /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
-		000000000B10 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
-		000000000B20 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
-		000000000B30 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
-		000000000B40 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
-		000000000B50 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
-		000000000B60 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
-		000000000B70 /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
-		000000000B80 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
-		000000000B90 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
-		000000000BA0 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
-		000000000BB0 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Mach/CwlPreconditionTesting.h; sourceTree = "<group>"; };
-		000000000BC0 /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
-		000000000BD0 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
-		000000000BE0 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Quick/Configuration/Configuration.swift; sourceTree = "<group>"; };
-		000000000BF0 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
-		000000000C00 /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
-		000000000C10 /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
-		000000000C20 /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
-		000000000C30 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
-		000000000C40 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
-		000000000C50 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
-		000000000C60 /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
-		000000000C70 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
-		000000000C80 /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
-		000000000C90 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
-		000000000CA0 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
-		000000000CB0 /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
-		000000000CC0 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
-		000000000CD0 /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
-		000000000CE0 /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
-		000000000CF0 /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Sources/Quick/World.swift; sourceTree = "<group>"; };
-		000000000D00 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
-		000000000D10 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
-		000000000D20 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
-		000000000D30 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Sources/QuickObjectiveC/DSL/QCKDSL.m; sourceTree = "<group>"; };
-		000000000D40 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
-		000000000D50 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
-		000000000D60 /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
-		000000000D70 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
-		000000000D80 /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
-		000000000D90 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickSpecBase/QuickSpecBase.m; sourceTree = "<group>"; };
-		000000000DA0 /* URITemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URITemplate.swift; path = Sources/URITemplate.swift; sourceTree = "<group>"; };
-		000000000DC0 /* Cara.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = Cara.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		000000000DD0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		000000000DE0 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		000000000E30 /* Cara.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Cara.framework; path = Cara.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000000E90 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		000000000F80 /* Cara.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Cara.xcconfig; sourceTree = "<group>"; };
-		000000000F90 /* Cara.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Cara.modulemap; sourceTree = "<group>"; };
-		000000000FA0 /* Cara-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Cara-umbrella.h"; sourceTree = "<group>"; };
-		000000000FC0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000000FD0 /* Cara-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Cara-prefix.pch"; sourceTree = "<group>"; };
-		000000000FE0 /* Cara-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Cara-dummy.m"; sourceTree = "<group>"; };
-		000000001040 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CryptoSwift.framework; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000001550 /* CryptoSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.xcconfig; sourceTree = "<group>"; };
-		000000001560 /* CryptoSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CryptoSwift.modulemap; sourceTree = "<group>"; };
-		000000001570 /* CryptoSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-umbrella.h"; sourceTree = "<group>"; };
-		000000001590 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		0000000015A0 /* CryptoSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-prefix.pch"; sourceTree = "<group>"; };
-		0000000015B0 /* CryptoSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CryptoSwift-dummy.m"; sourceTree = "<group>"; };
-		000000001610 /* Mockingjay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Mockingjay.framework; path = Mockingjay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000001700 /* Mockingjay.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Mockingjay.xcconfig; sourceTree = "<group>"; };
-		000000001710 /* Mockingjay.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Mockingjay.modulemap; sourceTree = "<group>"; };
-		000000001720 /* Mockingjay-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Mockingjay-umbrella.h"; sourceTree = "<group>"; };
-		000000001740 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000001750 /* Mockingjay-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Mockingjay-prefix.pch"; sourceTree = "<group>"; };
-		000000001760 /* Mockingjay-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Mockingjay-dummy.m"; sourceTree = "<group>"; };
-		0000000017C0 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000001C80 /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
-		000000001C90 /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
-		000000001CA0 /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
-		000000001CC0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000001CD0 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
-		000000001CE0 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
-		000000001D40 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Quick.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000001F90 /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
-		000000001FA0 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
-		000000001FB0 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
-		000000001FD0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000001FE0 /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
-		000000001FF0 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
-		000000002050 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = URITemplate.framework; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0000000020D0 /* URITemplate.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = URITemplate.xcconfig; sourceTree = "<group>"; };
-		0000000020E0 /* URITemplate.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = URITemplate.modulemap; sourceTree = "<group>"; };
-		0000000020F0 /* URITemplate-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-umbrella.h"; sourceTree = "<group>"; };
-		000000002110 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000002120 /* URITemplate-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-prefix.pch"; sourceTree = "<group>"; };
-		000000002130 /* URITemplate-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "URITemplate-dummy.m"; sourceTree = "<group>"; };
-		000000002190 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Tests.framework; path = "Pods-Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		000000002200 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
-		000000002210 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		000000002220 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		000000002230 /* Pods-Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Tests.modulemap"; sourceTree = "<group>"; };
-		000000002240 /* Pods-Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tests-umbrella.h"; sourceTree = "<group>"; };
-		000000002260 /* Pods-Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-frameworks.sh"; sourceTree = "<group>"; };
-		000000002270 /* Pods-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-resources.sh"; sourceTree = "<group>"; };
-		000000002280 /* Pods-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		000000002290 /* Pods-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		0000000022A0 /* Pods-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tests-dummy.m"; sourceTree = "<group>"; };
-		0000000022C0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		000000002330 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0000000023B0 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000180 /* ConsoleLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsoleLogger.swift; sourceTree = "<group>"; };
+		0000000001A0 /* Request+URLRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Request+URLRequest.swift"; sourceTree = "<group>"; };
+		0000000001B0 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		0000000001C0 /* RequestMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RequestMethod.swift; sourceTree = "<group>"; };
+		0000000001E0 /* CodableSerializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodableSerializer.swift; sourceTree = "<group>"; };
+		0000000001F0 /* Serializer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Serializer.swift; sourceTree = "<group>"; };
+		000000000210 /* NetworkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		000000000220 /* PublicKeyPinningService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PublicKeyPinningService.swift; sourceTree = "<group>"; };
+		000000000230 /* ResponseError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResponseError.swift; sourceTree = "<group>"; };
+		000000000240 /* Service.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
+		000000000250 /* AEAD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEAD.swift; path = Sources/CryptoSwift/AEAD/AEAD.swift; sourceTree = "<group>"; };
+		000000000260 /* AEADChaCha20Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEADChaCha20Poly1305.swift; path = Sources/CryptoSwift/AEAD/AEADChaCha20Poly1305.swift; sourceTree = "<group>"; };
+		000000000270 /* AES.Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.Cryptors.swift; path = Sources/CryptoSwift/AES.Cryptors.swift; sourceTree = "<group>"; };
+		000000000280 /* AES.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AES.swift; path = Sources/CryptoSwift/AES.swift; sourceTree = "<group>"; };
+		000000000290 /* Array+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extension.swift"; path = "Sources/CryptoSwift/Array+Extension.swift"; sourceTree = "<group>"; };
+		0000000002A0 /* Authenticator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Authenticator.swift; path = Sources/CryptoSwift/Authenticator.swift; sourceTree = "<group>"; };
+		0000000002B0 /* BatchedCollection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BatchedCollection.swift; path = Sources/CryptoSwift/BatchedCollection.swift; sourceTree = "<group>"; };
+		0000000002C0 /* Bit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bit.swift; path = Sources/CryptoSwift/Bit.swift; sourceTree = "<group>"; };
+		0000000002D0 /* BlockCipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockCipher.swift; path = Sources/CryptoSwift/BlockCipher.swift; sourceTree = "<group>"; };
+		0000000002E0 /* BlockDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockDecryptor.swift; path = Sources/CryptoSwift/BlockDecryptor.swift; sourceTree = "<group>"; };
+		0000000002F0 /* BlockEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockEncryptor.swift; path = Sources/CryptoSwift/BlockEncryptor.swift; sourceTree = "<group>"; };
+		000000000300 /* BlockMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockMode.swift; path = Sources/CryptoSwift/BlockMode/BlockMode.swift; sourceTree = "<group>"; };
+		000000000310 /* BlockModeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockModeOptions.swift; path = Sources/CryptoSwift/BlockMode/BlockModeOptions.swift; sourceTree = "<group>"; };
+		000000000320 /* CBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBC.swift; path = Sources/CryptoSwift/BlockMode/CBC.swift; sourceTree = "<group>"; };
+		000000000330 /* CCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CCM.swift; path = Sources/CryptoSwift/BlockMode/CCM.swift; sourceTree = "<group>"; };
+		000000000340 /* CFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CFB.swift; path = Sources/CryptoSwift/BlockMode/CFB.swift; sourceTree = "<group>"; };
+		000000000350 /* CipherModeWorker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CipherModeWorker.swift; path = Sources/CryptoSwift/BlockMode/CipherModeWorker.swift; sourceTree = "<group>"; };
+		000000000360 /* CTR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CTR.swift; path = Sources/CryptoSwift/BlockMode/CTR.swift; sourceTree = "<group>"; };
+		000000000370 /* ECB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ECB.swift; path = Sources/CryptoSwift/BlockMode/ECB.swift; sourceTree = "<group>"; };
+		000000000380 /* GCM.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GCM.swift; path = Sources/CryptoSwift/BlockMode/GCM.swift; sourceTree = "<group>"; };
+		000000000390 /* OFB.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OFB.swift; path = Sources/CryptoSwift/BlockMode/OFB.swift; sourceTree = "<group>"; };
+		0000000003A0 /* PCBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PCBC.swift; path = Sources/CryptoSwift/BlockMode/PCBC.swift; sourceTree = "<group>"; };
+		0000000003B0 /* Blowfish.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Blowfish.swift; path = Sources/CryptoSwift/Blowfish.swift; sourceTree = "<group>"; };
+		0000000003C0 /* CBCMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBCMAC.swift; path = Sources/CryptoSwift/CBCMAC.swift; sourceTree = "<group>"; };
+		0000000003D0 /* ChaCha20.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChaCha20.swift; path = Sources/CryptoSwift/ChaCha20.swift; sourceTree = "<group>"; };
+		0000000003E0 /* Checksum.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Checksum.swift; path = Sources/CryptoSwift/Checksum.swift; sourceTree = "<group>"; };
+		0000000003F0 /* Cipher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cipher.swift; path = Sources/CryptoSwift/Cipher.swift; sourceTree = "<group>"; };
+		000000000400 /* CMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CMAC.swift; path = Sources/CryptoSwift/CMAC.swift; sourceTree = "<group>"; };
+		000000000410 /* Collection+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Collection+Extension.swift"; path = "Sources/CryptoSwift/Collection+Extension.swift"; sourceTree = "<group>"; };
+		000000000420 /* CompactMap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompactMap.swift; path = Sources/CryptoSwift/CompactMap.swift; sourceTree = "<group>"; };
+		000000000430 /* Cryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptor.swift; path = Sources/CryptoSwift/Cryptor.swift; sourceTree = "<group>"; };
+		000000000440 /* Cryptors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptors.swift; path = Sources/CryptoSwift/Cryptors.swift; sourceTree = "<group>"; };
+		000000000450 /* Digest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Digest.swift; path = Sources/CryptoSwift/Digest.swift; sourceTree = "<group>"; };
+		000000000460 /* DigestType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DigestType.swift; path = Sources/CryptoSwift/DigestType.swift; sourceTree = "<group>"; };
+		000000000470 /* AES+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AES+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/AES+Foundation.swift"; sourceTree = "<group>"; };
+		000000000480 /* Array+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Array+Foundation.swift"; sourceTree = "<group>"; };
+		000000000490 /* Blowfish+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Blowfish+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Blowfish+Foundation.swift"; sourceTree = "<group>"; };
+		0000000004A0 /* ChaCha20+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ChaCha20+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/ChaCha20+Foundation.swift"; sourceTree = "<group>"; };
+		0000000004B0 /* Data+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Extension.swift"; path = "Sources/CryptoSwift/Foundation/Data+Extension.swift"; sourceTree = "<group>"; };
+		0000000004C0 /* HMAC+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "HMAC+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/HMAC+Foundation.swift"; sourceTree = "<group>"; };
+		0000000004D0 /* Rabbit+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Rabbit+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Rabbit+Foundation.swift"; sourceTree = "<group>"; };
+		0000000004E0 /* String+FoundationExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+FoundationExtension.swift"; path = "Sources/CryptoSwift/Foundation/String+FoundationExtension.swift"; sourceTree = "<group>"; };
+		0000000004F0 /* Utils+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Utils+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/Utils+Foundation.swift"; sourceTree = "<group>"; };
+		000000000500 /* Generics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generics.swift; path = Sources/CryptoSwift/Generics.swift; sourceTree = "<group>"; };
+		000000000510 /* HKDF.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HKDF.swift; path = Sources/CryptoSwift/HKDF.swift; sourceTree = "<group>"; };
+		000000000520 /* HMAC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HMAC.swift; path = Sources/CryptoSwift/HMAC.swift; sourceTree = "<group>"; };
+		000000000530 /* Int+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Int+Extension.swift"; path = "Sources/CryptoSwift/Int+Extension.swift"; sourceTree = "<group>"; };
+		000000000540 /* MD5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MD5.swift; path = Sources/CryptoSwift/MD5.swift; sourceTree = "<group>"; };
+		000000000550 /* NoPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoPadding.swift; path = Sources/CryptoSwift/NoPadding.swift; sourceTree = "<group>"; };
+		000000000560 /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Sources/CryptoSwift/Operators.swift; sourceTree = "<group>"; };
+		000000000570 /* Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Padding.swift; path = Sources/CryptoSwift/Padding.swift; sourceTree = "<group>"; };
+		000000000580 /* PBKDF1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF1.swift; path = Sources/CryptoSwift/PKCS/PBKDF1.swift; sourceTree = "<group>"; };
+		000000000590 /* PBKDF2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PBKDF2.swift; path = Sources/CryptoSwift/PKCS/PBKDF2.swift; sourceTree = "<group>"; };
+		0000000005A0 /* PKCS5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS5.swift; path = Sources/CryptoSwift/PKCS/PKCS5.swift; sourceTree = "<group>"; };
+		0000000005B0 /* PKCS7.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7.swift; path = Sources/CryptoSwift/PKCS/PKCS7.swift; sourceTree = "<group>"; };
+		0000000005C0 /* PKCS7Padding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS7Padding.swift; path = Sources/CryptoSwift/PKCS/PKCS7Padding.swift; sourceTree = "<group>"; };
+		0000000005D0 /* Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Poly1305.swift; path = Sources/CryptoSwift/Poly1305.swift; sourceTree = "<group>"; };
+		0000000005E0 /* Rabbit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rabbit.swift; path = Sources/CryptoSwift/Rabbit.swift; sourceTree = "<group>"; };
+		0000000005F0 /* RandomBytesSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RandomBytesSequence.swift; path = Sources/CryptoSwift/RandomBytesSequence.swift; sourceTree = "<group>"; };
+		000000000600 /* SecureBytes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecureBytes.swift; path = Sources/CryptoSwift/SecureBytes.swift; sourceTree = "<group>"; };
+		000000000610 /* SHA1.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA1.swift; path = Sources/CryptoSwift/SHA1.swift; sourceTree = "<group>"; };
+		000000000620 /* SHA2.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA2.swift; path = Sources/CryptoSwift/SHA2.swift; sourceTree = "<group>"; };
+		000000000630 /* SHA3.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SHA3.swift; path = Sources/CryptoSwift/SHA3.swift; sourceTree = "<group>"; };
+		000000000640 /* StreamDecryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamDecryptor.swift; path = Sources/CryptoSwift/StreamDecryptor.swift; sourceTree = "<group>"; };
+		000000000650 /* StreamEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamEncryptor.swift; path = Sources/CryptoSwift/StreamEncryptor.swift; sourceTree = "<group>"; };
+		000000000660 /* String+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Extension.swift"; path = "Sources/CryptoSwift/String+Extension.swift"; sourceTree = "<group>"; };
+		000000000670 /* UInt128.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UInt128.swift; path = Sources/CryptoSwift/UInt128.swift; sourceTree = "<group>"; };
+		000000000680 /* UInt16+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt16+Extension.swift"; path = "Sources/CryptoSwift/UInt16+Extension.swift"; sourceTree = "<group>"; };
+		000000000690 /* UInt32+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt32+Extension.swift"; path = "Sources/CryptoSwift/UInt32+Extension.swift"; sourceTree = "<group>"; };
+		0000000006A0 /* UInt64+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt64+Extension.swift"; path = "Sources/CryptoSwift/UInt64+Extension.swift"; sourceTree = "<group>"; };
+		0000000006B0 /* UInt8+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt8+Extension.swift"; path = "Sources/CryptoSwift/UInt8+Extension.swift"; sourceTree = "<group>"; };
+		0000000006C0 /* Updatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Updatable.swift; path = Sources/CryptoSwift/Updatable.swift; sourceTree = "<group>"; };
+		0000000006D0 /* Utils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = Sources/CryptoSwift/Utils.swift; sourceTree = "<group>"; };
+		0000000006E0 /* ZeroPadding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ZeroPadding.swift; path = Sources/CryptoSwift/ZeroPadding.swift; sourceTree = "<group>"; };
+		000000000700 /* Mockingjay.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Mockingjay.h; path = Sources/Mockingjay/Mockingjay.h; sourceTree = "<group>"; };
+		000000000710 /* Mockingjay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Mockingjay.swift; path = Sources/Mockingjay/Mockingjay.swift; sourceTree = "<group>"; };
+		000000000720 /* MockingjayProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockingjayProtocol.swift; path = Sources/Mockingjay/MockingjayProtocol.swift; sourceTree = "<group>"; };
+		000000000730 /* Builders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Builders.swift; path = Sources/Mockingjay/Builders.swift; sourceTree = "<group>"; };
+		000000000740 /* Matchers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Matchers.swift; path = Sources/Mockingjay/Matchers.swift; sourceTree = "<group>"; };
+		000000000750 /* NSURLSessionConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSURLSessionConfiguration.swift; path = Sources/Mockingjay/NSURLSessionConfiguration.swift; sourceTree = "<group>"; };
+		000000000760 /* MockingjayURLSessionConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MockingjayURLSessionConfiguration.m; path = Sources/Mockingjay/MockingjayURLSessionConfiguration.m; sourceTree = "<group>"; };
+		000000000780 /* XCTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XCTest.swift; path = Sources/Mockingjay/XCTest.swift; sourceTree = "<group>"; };
+		000000000790 /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
+		0000000007A0 /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
+		0000000007B0 /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
+		0000000007C0 /* NimbleEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleEnvironment.swift; path = Sources/Nimble/Adapters/NimbleEnvironment.swift; sourceTree = "<group>"; };
+		0000000007D0 /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
+		0000000007E0 /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
+		0000000007F0 /* NMBObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBObjCMatcher.swift; path = Sources/Nimble/Adapters/NMBObjCMatcher.swift; sourceTree = "<group>"; };
+		000000000800 /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
+		000000000810 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
+		000000000820 /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
+		000000000830 /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
+		000000000840 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
+		000000000850 /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
+		000000000860 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
+		000000000870 /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Matchers/Async.swift; sourceTree = "<group>"; };
+		000000000880 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
+		000000000890 /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
+		0000000008A0 /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
+		0000000008B0 /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
+		0000000008C0 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
+		0000000008D0 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
+		0000000008E0 /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
+		0000000008F0 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
+		000000000900 /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
+		000000000910 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
+		000000000920 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
+		000000000930 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
+		000000000940 /* BeVoid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeVoid.swift; path = Sources/Nimble/Matchers/BeVoid.swift; sourceTree = "<group>"; };
+		000000000950 /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
+		000000000960 /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
+		000000000970 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
+		000000000980 /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Sources/Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
+		000000000990 /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
+		0000000009A0 /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
+		0000000009B0 /* MatcherFunc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherFunc.swift; path = Sources/Nimble/Matchers/MatcherFunc.swift; sourceTree = "<group>"; };
+		0000000009C0 /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
+		0000000009D0 /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
+		0000000009E0 /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
+		0000000009F0 /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
+		000000000A00 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
+		000000000A10 /* SatisfyAllOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAllOf.swift; path = Sources/Nimble/Matchers/SatisfyAllOf.swift; sourceTree = "<group>"; };
+		000000000A20 /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
+		000000000A30 /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
+		000000000A40 /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
+		000000000A50 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
+		000000000A60 /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
+		000000000A70 /* Await.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Await.swift; path = Sources/Nimble/Utils/Await.swift; sourceTree = "<group>"; };
+		000000000A80 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
+		000000000A90 /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Sources/Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
+		000000000AA0 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
+		000000000AB0 /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
+		000000000AC0 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
+		000000000AD0 /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
+		000000000AE0 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
+		000000000AF0 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
+		000000000B00 /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
+		000000000B10 /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
+		000000000B20 /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
+		000000000B30 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
+		000000000B40 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
+		000000000B50 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
+		000000000B60 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
+		000000000B70 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
+		000000000B80 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		000000000B90 /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
+		000000000BA0 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		000000000BB0 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
+		000000000BC0 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
+		000000000BD0 /* CwlPreconditionTesting.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlPreconditionTesting.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/Mach/CwlPreconditionTesting.h; sourceTree = "<group>"; };
+		000000000BE0 /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
+		000000000BF0 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
+		000000000C00 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Sources/Quick/Configuration/Configuration.swift; sourceTree = "<group>"; };
+		000000000C10 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
+		000000000C20 /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
+		000000000C30 /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
+		000000000C40 /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
+		000000000C50 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
+		000000000C60 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
+		000000000C70 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
+		000000000C80 /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
+		000000000C90 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
+		000000000CA0 /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
+		000000000CB0 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
+		000000000CC0 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
+		000000000CD0 /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
+		000000000CE0 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
+		000000000CF0 /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
+		000000000D00 /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
+		000000000D10 /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Sources/Quick/World.swift; sourceTree = "<group>"; };
+		000000000D20 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
+		000000000D30 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
+		000000000D40 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
+		000000000D50 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Sources/QuickObjectiveC/DSL/QCKDSL.m; sourceTree = "<group>"; };
+		000000000D60 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
+		000000000D70 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
+		000000000D80 /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
+		000000000D90 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
+		000000000DA0 /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
+		000000000DB0 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickSpecBase/QuickSpecBase.m; sourceTree = "<group>"; };
+		000000000DC0 /* URITemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URITemplate.swift; path = Sources/URITemplate.swift; sourceTree = "<group>"; };
+		000000000DE0 /* Cara.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = Cara.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		000000000DF0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		000000000E00 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		000000000E50 /* Cara.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cara.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000EB0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		000000000FB0 /* Cara.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Cara.xcconfig; sourceTree = "<group>"; };
+		000000000FC0 /* Cara.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Cara.modulemap; sourceTree = "<group>"; };
+		000000000FD0 /* Cara-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Cara-umbrella.h"; sourceTree = "<group>"; };
+		000000000FF0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000001000 /* Cara-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Cara-prefix.pch"; sourceTree = "<group>"; };
+		000000001010 /* Cara-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Cara-dummy.m"; sourceTree = "<group>"; };
+		000000001070 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000001580 /* CryptoSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CryptoSwift.xcconfig; sourceTree = "<group>"; };
+		000000001590 /* CryptoSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CryptoSwift.modulemap; sourceTree = "<group>"; };
+		0000000015A0 /* CryptoSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-umbrella.h"; sourceTree = "<group>"; };
+		0000000015C0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0000000015D0 /* CryptoSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-prefix.pch"; sourceTree = "<group>"; };
+		0000000015E0 /* CryptoSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CryptoSwift-dummy.m"; sourceTree = "<group>"; };
+		000000001640 /* Mockingjay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mockingjay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000001730 /* Mockingjay.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Mockingjay.xcconfig; sourceTree = "<group>"; };
+		000000001740 /* Mockingjay.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Mockingjay.modulemap; sourceTree = "<group>"; };
+		000000001750 /* Mockingjay-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Mockingjay-umbrella.h"; sourceTree = "<group>"; };
+		000000001770 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000001780 /* Mockingjay-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Mockingjay-prefix.pch"; sourceTree = "<group>"; };
+		000000001790 /* Mockingjay-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Mockingjay-dummy.m"; sourceTree = "<group>"; };
+		0000000017F0 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000001CB0 /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
+		000000001CC0 /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
+		000000001CD0 /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
+		000000001CF0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000001D00 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
+		000000001D10 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
+		000000001D70 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000001FC0 /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
+		000000001FD0 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
+		000000001FE0 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
+		000000002000 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000002010 /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
+		000000002020 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
+		000000002080 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000002100 /* URITemplate.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = URITemplate.xcconfig; sourceTree = "<group>"; };
+		000000002110 /* URITemplate.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = URITemplate.modulemap; sourceTree = "<group>"; };
+		000000002120 /* URITemplate-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-umbrella.h"; sourceTree = "<group>"; };
+		000000002140 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000002150 /* URITemplate-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-prefix.pch"; sourceTree = "<group>"; };
+		000000002160 /* URITemplate-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "URITemplate-dummy.m"; sourceTree = "<group>"; };
+		0000000021C0 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000002230 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		000000002240 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		000000002250 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		000000002260 /* Pods-Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Tests.modulemap"; sourceTree = "<group>"; };
+		000000002270 /* Pods-Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tests-umbrella.h"; sourceTree = "<group>"; };
+		000000002290 /* Pods-Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-frameworks.sh"; sourceTree = "<group>"; };
+		0000000022A0 /* Pods-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-resources.sh"; sourceTree = "<group>"; };
+		0000000022B0 /* Pods-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		0000000022C0 /* Pods-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		0000000022D0 /* Pods-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tests-dummy.m"; sourceTree = "<group>"; };
+		0000000022F0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		000000002360 /* CryptoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CryptoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0000000023E0 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9D21FEFF21D92A4B006EF131 /* OSLog+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OSLog+Request.swift"; sourceTree = "<group>"; };
+		9D21FF0121D92A5F006EF131 /* Configuration+Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+Logger.swift"; sourceTree = "<group>"; };
+		9D21FF0321D92A70006EF131 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		000000000E60 /* Frameworks */ = {
+		000000000E80 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000002340 /* CryptoSwift.framework in Frameworks */,
-				000000000EA0 /* Foundation.framework in Frameworks */,
+				000000002370 /* CryptoSwift.framework in Frameworks */,
+				000000000EC0 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001070 /* Frameworks */ = {
+		0000000010A0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001090 /* Foundation.framework in Frameworks */,
+				0000000010C0 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001640 /* Frameworks */ = {
+		000000001670 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001660 /* Foundation.framework in Frameworks */,
-				0000000023C0 /* URITemplate.framework in Frameworks */,
-				0000000022D0 /* XCTest.framework in Frameworks */,
+				000000001690 /* Foundation.framework in Frameworks */,
+				0000000023F0 /* URITemplate.framework in Frameworks */,
+				000000002300 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000017F0 /* Frameworks */ = {
+		000000001820 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001810 /* Foundation.framework in Frameworks */,
+				000000001840 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001D70 /* Frameworks */ = {
+		000000001DA0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001D90 /* Foundation.framework in Frameworks */,
-				0000000022E0 /* XCTest.framework in Frameworks */,
+				000000001DC0 /* Foundation.framework in Frameworks */,
+				000000002310 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000002080 /* Frameworks */ = {
+		0000000020B0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000020A0 /* Foundation.framework in Frameworks */,
+				0000000020D0 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000021C0 /* Frameworks */ = {
+		0000000021F0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000021E0 /* Foundation.framework in Frameworks */,
+				000000002210 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -624,13 +632,13 @@
 		000000000020 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				000000000E30 /* Cara.framework */,
-				000000001040 /* CryptoSwift.framework */,
-				000000001610 /* Mockingjay.framework */,
-				0000000017C0 /* Nimble.framework */,
-				000000002190 /* Pods_Tests.framework */,
-				000000001D40 /* Quick.framework */,
-				000000002050 /* URITemplate.framework */,
+				000000000E50 /* Cara.framework */,
+				000000001070 /* CryptoSwift.framework */,
+				000000001640 /* Mockingjay.framework */,
+				0000000017F0 /* Nimble.framework */,
+				0000000021C0 /* Pods_Tests.framework */,
+				000000001D70 /* Quick.framework */,
+				000000002080 /* URITemplate.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -638,9 +646,9 @@
 		000000000060 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				000000002330 /* CryptoSwift.framework */,
-				0000000023B0 /* URITemplate.framework */,
-				000000000E80 /* iOS */,
+				000000002360 /* CryptoSwift.framework */,
+				0000000023E0 /* URITemplate.framework */,
+				000000000EA0 /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -648,7 +656,7 @@
 		000000000070 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				0000000021F0 /* Pods-Tests */,
+				000000002220 /* Pods-Tests */,
 			);
 			name = "Targets Support Files";
 			sourceTree = "<group>";
@@ -679,11 +687,12 @@
 			children = (
 				000000000120 /* Configuration */,
 				000000000140 /* Extensions */,
-				000000000DB0 /* Pod */,
-				000000000170 /* Request */,
-				0000000001B0 /* Serializer */,
-				0000000001E0 /* Service */,
-				000000000F70 /* Support Files */,
+				000000000170 /* Logger */,
+				000000000DD0 /* Pod */,
+				000000000190 /* Request */,
+				0000000001D0 /* Serializer */,
+				000000000200 /* Service */,
+				000000000FA0 /* Support Files */,
 			);
 			name = Cara;
 			path = ../..;
@@ -692,211 +701,207 @@
 		0000000000B0 /* CryptoSwift */ = {
 			isa = PBXGroup;
 			children = (
-				000000000230 /* AEAD.swift */,
-				000000000240 /* AEADChaCha20Poly1305.swift */,
-				000000000260 /* AES.swift */,
-				000000000450 /* AES+Foundation.swift */,
-				000000000250 /* AES.Cryptors.swift */,
-				000000000270 /* Array+Extension.swift */,
-				000000000460 /* Array+Foundation.swift */,
-				000000000280 /* Authenticator.swift */,
-				000000000290 /* BatchedCollection.swift */,
-				0000000002A0 /* Bit.swift */,
-				0000000002B0 /* BlockCipher.swift */,
-				0000000002C0 /* BlockDecryptor.swift */,
-				0000000002D0 /* BlockEncryptor.swift */,
-				0000000002E0 /* BlockMode.swift */,
-				0000000002F0 /* BlockModeOptions.swift */,
-				000000000390 /* Blowfish.swift */,
-				000000000470 /* Blowfish+Foundation.swift */,
-				000000000300 /* CBC.swift */,
-				0000000003A0 /* CBCMAC.swift */,
-				000000000310 /* CCM.swift */,
-				000000000320 /* CFB.swift */,
-				0000000003B0 /* ChaCha20.swift */,
-				000000000480 /* ChaCha20+Foundation.swift */,
-				0000000003C0 /* Checksum.swift */,
-				0000000003D0 /* Cipher.swift */,
-				000000000330 /* CipherModeWorker.swift */,
-				0000000003E0 /* CMAC.swift */,
-				0000000003F0 /* Collection+Extension.swift */,
-				000000000400 /* CompactMap.swift */,
-				000000000410 /* Cryptor.swift */,
-				000000000420 /* Cryptors.swift */,
-				000000000340 /* CTR.swift */,
-				000000000490 /* Data+Extension.swift */,
-				000000000430 /* Digest.swift */,
-				000000000440 /* DigestType.swift */,
-				000000000350 /* ECB.swift */,
-				000000000360 /* GCM.swift */,
-				0000000004E0 /* Generics.swift */,
-				0000000004F0 /* HKDF.swift */,
-				000000000500 /* HMAC.swift */,
-				0000000004A0 /* HMAC+Foundation.swift */,
-				000000000510 /* Int+Extension.swift */,
-				000000000520 /* MD5.swift */,
-				000000000530 /* NoPadding.swift */,
-				000000000370 /* OFB.swift */,
-				000000000540 /* Operators.swift */,
-				000000000550 /* Padding.swift */,
-				000000000560 /* PBKDF1.swift */,
-				000000000570 /* PBKDF2.swift */,
-				000000000380 /* PCBC.swift */,
-				000000000580 /* PKCS5.swift */,
-				000000000590 /* PKCS7.swift */,
-				0000000005A0 /* PKCS7Padding.swift */,
-				0000000005B0 /* Poly1305.swift */,
-				0000000005C0 /* Rabbit.swift */,
-				0000000004B0 /* Rabbit+Foundation.swift */,
-				0000000005D0 /* RandomBytesSequence.swift */,
-				0000000005E0 /* SecureBytes.swift */,
-				0000000005F0 /* SHA1.swift */,
-				000000000600 /* SHA2.swift */,
-				000000000610 /* SHA3.swift */,
-				000000000620 /* StreamDecryptor.swift */,
-				000000000630 /* StreamEncryptor.swift */,
-				000000000640 /* String+Extension.swift */,
-				0000000004C0 /* String+FoundationExtension.swift */,
-				000000000650 /* UInt128.swift */,
-				000000000660 /* UInt16+Extension.swift */,
-				000000000670 /* UInt32+Extension.swift */,
-				000000000680 /* UInt64+Extension.swift */,
-				000000000690 /* UInt8+Extension.swift */,
-				0000000006A0 /* Updatable.swift */,
-				0000000006B0 /* Utils.swift */,
-				0000000004D0 /* Utils+Foundation.swift */,
-				0000000006C0 /* ZeroPadding.swift */,
-				000000001540 /* Support Files */,
+				000000000250 /* AEAD.swift */,
+				000000000260 /* AEADChaCha20Poly1305.swift */,
+				000000000280 /* AES.swift */,
+				000000000470 /* AES+Foundation.swift */,
+				000000000270 /* AES.Cryptors.swift */,
+				000000000290 /* Array+Extension.swift */,
+				000000000480 /* Array+Foundation.swift */,
+				0000000002A0 /* Authenticator.swift */,
+				0000000002B0 /* BatchedCollection.swift */,
+				0000000002C0 /* Bit.swift */,
+				0000000002D0 /* BlockCipher.swift */,
+				0000000002E0 /* BlockDecryptor.swift */,
+				0000000002F0 /* BlockEncryptor.swift */,
+				000000000300 /* BlockMode.swift */,
+				000000000310 /* BlockModeOptions.swift */,
+				0000000003B0 /* Blowfish.swift */,
+				000000000490 /* Blowfish+Foundation.swift */,
+				000000000320 /* CBC.swift */,
+				0000000003C0 /* CBCMAC.swift */,
+				000000000330 /* CCM.swift */,
+				000000000340 /* CFB.swift */,
+				0000000003D0 /* ChaCha20.swift */,
+				0000000004A0 /* ChaCha20+Foundation.swift */,
+				0000000003E0 /* Checksum.swift */,
+				0000000003F0 /* Cipher.swift */,
+				000000000350 /* CipherModeWorker.swift */,
+				000000000400 /* CMAC.swift */,
+				000000000410 /* Collection+Extension.swift */,
+				000000000420 /* CompactMap.swift */,
+				000000000430 /* Cryptor.swift */,
+				000000000440 /* Cryptors.swift */,
+				000000000360 /* CTR.swift */,
+				0000000004B0 /* Data+Extension.swift */,
+				000000000450 /* Digest.swift */,
+				000000000460 /* DigestType.swift */,
+				000000000370 /* ECB.swift */,
+				000000000380 /* GCM.swift */,
+				000000000500 /* Generics.swift */,
+				000000000510 /* HKDF.swift */,
+				000000000520 /* HMAC.swift */,
+				0000000004C0 /* HMAC+Foundation.swift */,
+				000000000530 /* Int+Extension.swift */,
+				000000000540 /* MD5.swift */,
+				000000000550 /* NoPadding.swift */,
+				000000000390 /* OFB.swift */,
+				000000000560 /* Operators.swift */,
+				000000000570 /* Padding.swift */,
+				000000000580 /* PBKDF1.swift */,
+				000000000590 /* PBKDF2.swift */,
+				0000000003A0 /* PCBC.swift */,
+				0000000005A0 /* PKCS5.swift */,
+				0000000005B0 /* PKCS7.swift */,
+				0000000005C0 /* PKCS7Padding.swift */,
+				0000000005D0 /* Poly1305.swift */,
+				0000000005E0 /* Rabbit.swift */,
+				0000000004D0 /* Rabbit+Foundation.swift */,
+				0000000005F0 /* RandomBytesSequence.swift */,
+				000000000600 /* SecureBytes.swift */,
+				000000000610 /* SHA1.swift */,
+				000000000620 /* SHA2.swift */,
+				000000000630 /* SHA3.swift */,
+				000000000640 /* StreamDecryptor.swift */,
+				000000000650 /* StreamEncryptor.swift */,
+				000000000660 /* String+Extension.swift */,
+				0000000004E0 /* String+FoundationExtension.swift */,
+				000000000670 /* UInt128.swift */,
+				000000000680 /* UInt16+Extension.swift */,
+				000000000690 /* UInt32+Extension.swift */,
+				0000000006A0 /* UInt64+Extension.swift */,
+				0000000006B0 /* UInt8+Extension.swift */,
+				0000000006C0 /* Updatable.swift */,
+				0000000006D0 /* Utils.swift */,
+				0000000004F0 /* Utils+Foundation.swift */,
+				0000000006E0 /* ZeroPadding.swift */,
+				000000001570 /* Support Files */,
 			);
-			name = CryptoSwift;
 			path = CryptoSwift;
 			sourceTree = "<group>";
 		};
 		0000000000C0 /* Mockingjay */ = {
 			isa = PBXGroup;
 			children = (
-				0000000006D0 /* Core */,
-				0000000016F0 /* Support Files */,
-				000000000750 /* XCTest */,
+				0000000006F0 /* Core */,
+				000000001720 /* Support Files */,
+				000000000770 /* XCTest */,
 			);
-			name = Mockingjay;
 			path = Mockingjay;
 			sourceTree = "<group>";
 		};
 		0000000000D0 /* Nimble */ = {
 			isa = PBXGroup;
 			children = (
-				000000000770 /* AdapterProtocols.swift */,
-				000000000840 /* AllPass.swift */,
-				000000000780 /* AssertionDispatcher.swift */,
-				000000000790 /* AssertionRecorder.swift */,
-				000000000850 /* Async.swift */,
-				000000000A50 /* Await.swift */,
-				000000000860 /* BeAKindOf.swift */,
-				000000000870 /* BeAnInstanceOf.swift */,
-				000000000880 /* BeCloseTo.swift */,
-				000000000890 /* BeEmpty.swift */,
-				0000000008A0 /* BeginWith.swift */,
-				0000000008B0 /* BeGreaterThan.swift */,
-				0000000008C0 /* BeGreaterThanOrEqualTo.swift */,
-				0000000008D0 /* BeIdenticalTo.swift */,
-				0000000008E0 /* BeLessThan.swift */,
-				0000000008F0 /* BeLessThanOrEqual.swift */,
-				000000000900 /* BeLogical.swift */,
-				000000000910 /* BeNil.swift */,
-				000000000920 /* BeVoid.swift */,
-				000000000930 /* Contain.swift */,
-				000000000940 /* ContainElementSatisfying.swift */,
-				000000000B80 /* CwlBadInstructionException.swift */,
-				000000000B90 /* CwlCatchBadInstruction.swift */,
-				000000000B30 /* CwlCatchException.h */,
-				000000000B20 /* CwlCatchException.m */,
-				000000000B10 /* CwlCatchException.swift */,
-				000000000BA0 /* CwlDarwinDefinitions.swift */,
-				000000000B50 /* CwlMachBadInstructionHandler.h */,
-				000000000B40 /* CwlMachBadInstructionHandler.m */,
-				000000000BB0 /* CwlPreconditionTesting.h */,
-				000000000AA0 /* DSL.h */,
-				000000000AB0 /* DSL.m */,
-				0000000007F0 /* DSL.swift */,
-				0000000007E0 /* DSL+Wait.swift */,
-				000000000950 /* EndWith.swift */,
-				000000000960 /* Equal.swift */,
-				000000000A60 /* Errors.swift */,
-				000000000800 /* Expectation.swift */,
-				000000000810 /* ExpectationMessage.swift */,
-				000000000820 /* Expression.swift */,
-				000000000830 /* FailureMessage.swift */,
-				000000000A70 /* Functional.swift */,
-				000000000970 /* HaveCount.swift */,
-				000000000B60 /* mach_excServer.c */,
-				000000000B70 /* mach_excServer.h */,
-				000000000980 /* Match.swift */,
-				000000000990 /* MatcherFunc.swift */,
-				0000000009A0 /* MatcherProtocols.swift */,
-				0000000009B0 /* MatchError.swift */,
-				000000000A40 /* Nimble.h */,
-				0000000007A0 /* NimbleEnvironment.swift */,
-				0000000007B0 /* NimbleXCTestHandler.swift */,
-				000000000AC0 /* NMBExceptionCapture.h */,
-				000000000AD0 /* NMBExceptionCapture.m */,
-				0000000007C0 /* NMBExpectation.swift */,
-				0000000007D0 /* NMBObjCMatcher.swift */,
-				000000000AE0 /* NMBStringify.h */,
-				000000000AF0 /* NMBStringify.m */,
-				0000000009C0 /* PostNotification.swift */,
-				0000000009D0 /* Predicate.swift */,
-				0000000009E0 /* RaisesException.swift */,
-				0000000009F0 /* SatisfyAllOf.swift */,
-				000000000A00 /* SatisfyAnyOf.swift */,
-				000000000A80 /* SourceLocation.swift */,
-				000000000A90 /* Stringers.swift */,
-				000000000A10 /* ThrowAssertion.swift */,
-				000000000A20 /* ThrowError.swift */,
-				000000000A30 /* ToSucceed.swift */,
-				000000000B00 /* XCTestObservationCenter+Register.m */,
-				000000001C70 /* Support Files */,
+				000000000790 /* AdapterProtocols.swift */,
+				000000000860 /* AllPass.swift */,
+				0000000007A0 /* AssertionDispatcher.swift */,
+				0000000007B0 /* AssertionRecorder.swift */,
+				000000000870 /* Async.swift */,
+				000000000A70 /* Await.swift */,
+				000000000880 /* BeAKindOf.swift */,
+				000000000890 /* BeAnInstanceOf.swift */,
+				0000000008A0 /* BeCloseTo.swift */,
+				0000000008B0 /* BeEmpty.swift */,
+				0000000008C0 /* BeginWith.swift */,
+				0000000008D0 /* BeGreaterThan.swift */,
+				0000000008E0 /* BeGreaterThanOrEqualTo.swift */,
+				0000000008F0 /* BeIdenticalTo.swift */,
+				000000000900 /* BeLessThan.swift */,
+				000000000910 /* BeLessThanOrEqual.swift */,
+				000000000920 /* BeLogical.swift */,
+				000000000930 /* BeNil.swift */,
+				000000000940 /* BeVoid.swift */,
+				000000000950 /* Contain.swift */,
+				000000000960 /* ContainElementSatisfying.swift */,
+				000000000BA0 /* CwlBadInstructionException.swift */,
+				000000000BB0 /* CwlCatchBadInstruction.swift */,
+				000000000B50 /* CwlCatchException.h */,
+				000000000B40 /* CwlCatchException.m */,
+				000000000B30 /* CwlCatchException.swift */,
+				000000000BC0 /* CwlDarwinDefinitions.swift */,
+				000000000B70 /* CwlMachBadInstructionHandler.h */,
+				000000000B60 /* CwlMachBadInstructionHandler.m */,
+				000000000BD0 /* CwlPreconditionTesting.h */,
+				000000000AC0 /* DSL.h */,
+				000000000AD0 /* DSL.m */,
+				000000000810 /* DSL.swift */,
+				000000000800 /* DSL+Wait.swift */,
+				000000000970 /* EndWith.swift */,
+				000000000980 /* Equal.swift */,
+				000000000A80 /* Errors.swift */,
+				000000000820 /* Expectation.swift */,
+				000000000830 /* ExpectationMessage.swift */,
+				000000000840 /* Expression.swift */,
+				000000000850 /* FailureMessage.swift */,
+				000000000A90 /* Functional.swift */,
+				000000000990 /* HaveCount.swift */,
+				000000000B80 /* mach_excServer.c */,
+				000000000B90 /* mach_excServer.h */,
+				0000000009A0 /* Match.swift */,
+				0000000009B0 /* MatcherFunc.swift */,
+				0000000009C0 /* MatcherProtocols.swift */,
+				0000000009D0 /* MatchError.swift */,
+				000000000A60 /* Nimble.h */,
+				0000000007C0 /* NimbleEnvironment.swift */,
+				0000000007D0 /* NimbleXCTestHandler.swift */,
+				000000000AE0 /* NMBExceptionCapture.h */,
+				000000000AF0 /* NMBExceptionCapture.m */,
+				0000000007E0 /* NMBExpectation.swift */,
+				0000000007F0 /* NMBObjCMatcher.swift */,
+				000000000B00 /* NMBStringify.h */,
+				000000000B10 /* NMBStringify.m */,
+				0000000009E0 /* PostNotification.swift */,
+				0000000009F0 /* Predicate.swift */,
+				000000000A00 /* RaisesException.swift */,
+				000000000A10 /* SatisfyAllOf.swift */,
+				000000000A20 /* SatisfyAnyOf.swift */,
+				000000000AA0 /* SourceLocation.swift */,
+				000000000AB0 /* Stringers.swift */,
+				000000000A30 /* ThrowAssertion.swift */,
+				000000000A40 /* ThrowError.swift */,
+				000000000A50 /* ToSucceed.swift */,
+				000000000B20 /* XCTestObservationCenter+Register.m */,
+				000000001CA0 /* Support Files */,
 			);
-			name = Nimble;
 			path = Nimble;
 			sourceTree = "<group>";
 		};
 		0000000000E0 /* Quick */ = {
 			isa = PBXGroup;
 			children = (
-				000000000BC0 /* Behavior.swift */,
-				000000000BD0 /* Callsite.swift */,
-				000000000C60 /* Closures.swift */,
-				000000000BE0 /* Configuration.swift */,
-				000000000BF0 /* DSL.swift */,
-				000000000C10 /* ErrorUtility.swift */,
-				000000000C20 /* Example.swift */,
-				000000000C30 /* ExampleGroup.swift */,
-				000000000C70 /* ExampleHooks.swift */,
-				000000000C40 /* ExampleMetadata.swift */,
-				000000000C50 /* Filter.swift */,
-				000000000C80 /* HooksPhase.swift */,
-				000000000CA0 /* NSBundle+CurrentTestBundle.swift */,
-				000000000CB0 /* NSString+C99ExtendedIdentifier.swift */,
-				000000000D20 /* QCKDSL.h */,
-				000000000D30 /* QCKDSL.m */,
-				000000000D40 /* Quick.h */,
-				000000000D00 /* QuickConfiguration.h */,
-				000000000D10 /* QuickConfiguration.m */,
-				000000000CC0 /* QuickSelectedTestSuiteBuilder.swift */,
-				000000000D50 /* QuickSpec.h */,
-				000000000D60 /* QuickSpec.m */,
-				000000000D80 /* QuickSpecBase.h */,
-				000000000D90 /* QuickSpecBase.m */,
-				000000000CD0 /* QuickTestSuite.swift */,
-				000000000C90 /* SuiteHooks.swift */,
-				000000000CE0 /* URL+FileName.swift */,
-				000000000CF0 /* World.swift */,
-				000000000C00 /* World+DSL.swift */,
-				000000000D70 /* XCTestSuite+QuickTestSuiteBuilder.m */,
-				000000001F80 /* Support Files */,
+				000000000BE0 /* Behavior.swift */,
+				000000000BF0 /* Callsite.swift */,
+				000000000C80 /* Closures.swift */,
+				000000000C00 /* Configuration.swift */,
+				000000000C10 /* DSL.swift */,
+				000000000C30 /* ErrorUtility.swift */,
+				000000000C40 /* Example.swift */,
+				000000000C50 /* ExampleGroup.swift */,
+				000000000C90 /* ExampleHooks.swift */,
+				000000000C60 /* ExampleMetadata.swift */,
+				000000000C70 /* Filter.swift */,
+				000000000CA0 /* HooksPhase.swift */,
+				000000000CC0 /* NSBundle+CurrentTestBundle.swift */,
+				000000000CD0 /* NSString+C99ExtendedIdentifier.swift */,
+				000000000D40 /* QCKDSL.h */,
+				000000000D50 /* QCKDSL.m */,
+				000000000D60 /* Quick.h */,
+				000000000D20 /* QuickConfiguration.h */,
+				000000000D30 /* QuickConfiguration.m */,
+				000000000CE0 /* QuickSelectedTestSuiteBuilder.swift */,
+				000000000D70 /* QuickSpec.h */,
+				000000000D80 /* QuickSpec.m */,
+				000000000DA0 /* QuickSpecBase.h */,
+				000000000DB0 /* QuickSpecBase.m */,
+				000000000CF0 /* QuickTestSuite.swift */,
+				000000000CB0 /* SuiteHooks.swift */,
+				000000000D00 /* URL+FileName.swift */,
+				000000000D10 /* World.swift */,
+				000000000C20 /* World+DSL.swift */,
+				000000000D90 /* XCTestSuite+QuickTestSuiteBuilder.m */,
+				000000001FB0 /* Support Files */,
 			);
-			name = Quick;
 			path = Quick;
 			sourceTree = "<group>";
 		};
@@ -904,17 +909,15 @@
 			isa = PBXGroup;
 			children = (
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
 		000000000100 /* URITemplate */ = {
 			isa = PBXGroup;
 			children = (
-				000000000DA0 /* URITemplate.swift */,
-				0000000020C0 /* Support Files */,
+				000000000DC0 /* URITemplate.swift */,
+				0000000020F0 /* Support Files */,
 			);
-			name = URITemplate;
 			path = URITemplate;
 			sourceTree = "<group>";
 		};
@@ -937,177 +940,189 @@
 			path = Sources/Extensions;
 			sourceTree = "<group>";
 		};
-		000000000170 /* Request */ = {
+		000000000170 /* Logger */ = {
 			isa = PBXGroup;
 			children = (
-				000000000190 /* Request.swift */,
-				000000000180 /* Request+URLRequest.swift */,
-				0000000001A0 /* RequestMethod.swift */,
+				000000000180 /* ConsoleLogger.swift */,
+				9D21FEFF21D92A4B006EF131 /* OSLog+Request.swift */,
+				9D21FF0121D92A5F006EF131 /* Configuration+Logger.swift */,
+				9D21FF0321D92A70006EF131 /* Logger.swift */,
+			);
+			name = Logger;
+			path = Sources/Logger;
+			sourceTree = "<group>";
+		};
+		000000000190 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				0000000001B0 /* Request.swift */,
+				0000000001A0 /* Request+URLRequest.swift */,
+				0000000001C0 /* RequestMethod.swift */,
 			);
 			name = Request;
 			path = Sources/Request;
 			sourceTree = "<group>";
 		};
-		0000000001B0 /* Serializer */ = {
+		0000000001D0 /* Serializer */ = {
 			isa = PBXGroup;
 			children = (
-				0000000001C0 /* CodableSerializer.swift */,
-				0000000001D0 /* Serializer.swift */,
+				0000000001E0 /* CodableSerializer.swift */,
+				0000000001F0 /* Serializer.swift */,
 			);
 			name = Serializer;
 			path = Sources/Serializer;
 			sourceTree = "<group>";
 		};
-		0000000001E0 /* Service */ = {
+		000000000200 /* Service */ = {
 			isa = PBXGroup;
 			children = (
-				0000000001F0 /* NetworkService.swift */,
-				000000000200 /* PublicKeyPinningService.swift */,
-				000000000210 /* ResponseError.swift */,
-				000000000220 /* Service.swift */,
+				000000000210 /* NetworkService.swift */,
+				000000000220 /* PublicKeyPinningService.swift */,
+				000000000230 /* ResponseError.swift */,
+				000000000240 /* Service.swift */,
 			);
 			name = Service;
 			path = Sources/Service;
 			sourceTree = "<group>";
 		};
-		0000000006D0 /* Core */ = {
+		0000000006F0 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				000000000710 /* Builders.swift */,
-				000000000720 /* Matchers.swift */,
-				0000000006E0 /* Mockingjay.h */,
-				0000000006F0 /* Mockingjay.swift */,
-				000000000700 /* MockingjayProtocol.swift */,
-				000000000740 /* MockingjayURLSessionConfiguration.m */,
-				000000000730 /* NSURLSessionConfiguration.swift */,
+				000000000730 /* Builders.swift */,
+				000000000740 /* Matchers.swift */,
+				000000000700 /* Mockingjay.h */,
+				000000000710 /* Mockingjay.swift */,
+				000000000720 /* MockingjayProtocol.swift */,
+				000000000760 /* MockingjayURLSessionConfiguration.m */,
+				000000000750 /* NSURLSessionConfiguration.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";
 		};
-		000000000750 /* XCTest */ = {
+		000000000770 /* XCTest */ = {
 			isa = PBXGroup;
 			children = (
-				000000000760 /* XCTest.swift */,
+				000000000780 /* XCTest.swift */,
 			);
 			name = XCTest;
 			sourceTree = "<group>";
 		};
-		000000000DB0 /* Pod */ = {
+		000000000DD0 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				000000000DC0 /* Cara.podspec */,
-				000000000DD0 /* LICENSE */,
-				000000000DE0 /* README.md */,
+				000000000DE0 /* Cara.podspec */,
+				000000000DF0 /* LICENSE */,
+				000000000E00 /* README.md */,
 			);
 			name = Pod;
 			sourceTree = "<group>";
 		};
-		000000000E80 /* iOS */ = {
+		000000000EA0 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				000000000E90 /* Foundation.framework */,
-				0000000022C0 /* XCTest.framework */,
+				000000000EB0 /* Foundation.framework */,
+				0000000022F0 /* XCTest.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		000000000F70 /* Support Files */ = {
+		000000000FA0 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000000F90 /* Cara.modulemap */,
-				000000000F80 /* Cara.xcconfig */,
-				000000000FE0 /* Cara-dummy.m */,
-				000000000FD0 /* Cara-prefix.pch */,
-				000000000FA0 /* Cara-umbrella.h */,
-				000000000FC0 /* Info.plist */,
+				000000000FC0 /* Cara.modulemap */,
+				000000000FB0 /* Cara.xcconfig */,
+				000000001010 /* Cara-dummy.m */,
+				000000001000 /* Cara-prefix.pch */,
+				000000000FD0 /* Cara-umbrella.h */,
+				000000000FF0 /* Info.plist */,
 			);
 			name = "Support Files";
 			path = "Example/Pods/Target Support Files/Cara";
 			sourceTree = "<group>";
 		};
-		000000001540 /* Support Files */ = {
+		000000001570 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000001560 /* CryptoSwift.modulemap */,
-				000000001550 /* CryptoSwift.xcconfig */,
-				0000000015B0 /* CryptoSwift-dummy.m */,
-				0000000015A0 /* CryptoSwift-prefix.pch */,
-				000000001570 /* CryptoSwift-umbrella.h */,
-				000000001590 /* Info.plist */,
+				000000001590 /* CryptoSwift.modulemap */,
+				000000001580 /* CryptoSwift.xcconfig */,
+				0000000015E0 /* CryptoSwift-dummy.m */,
+				0000000015D0 /* CryptoSwift-prefix.pch */,
+				0000000015A0 /* CryptoSwift-umbrella.h */,
+				0000000015C0 /* Info.plist */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/CryptoSwift";
 			sourceTree = "<group>";
 		};
-		0000000016F0 /* Support Files */ = {
+		000000001720 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000001740 /* Info.plist */,
-				000000001710 /* Mockingjay.modulemap */,
-				000000001700 /* Mockingjay.xcconfig */,
-				000000001760 /* Mockingjay-dummy.m */,
-				000000001750 /* Mockingjay-prefix.pch */,
-				000000001720 /* Mockingjay-umbrella.h */,
+				000000001770 /* Info.plist */,
+				000000001740 /* Mockingjay.modulemap */,
+				000000001730 /* Mockingjay.xcconfig */,
+				000000001790 /* Mockingjay-dummy.m */,
+				000000001780 /* Mockingjay-prefix.pch */,
+				000000001750 /* Mockingjay-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Mockingjay";
 			sourceTree = "<group>";
 		};
-		000000001C70 /* Support Files */ = {
+		000000001CA0 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000001CC0 /* Info.plist */,
-				000000001C90 /* Nimble.modulemap */,
-				000000001C80 /* Nimble.xcconfig */,
-				000000001CE0 /* Nimble-dummy.m */,
-				000000001CD0 /* Nimble-prefix.pch */,
-				000000001CA0 /* Nimble-umbrella.h */,
+				000000001CF0 /* Info.plist */,
+				000000001CC0 /* Nimble.modulemap */,
+				000000001CB0 /* Nimble.xcconfig */,
+				000000001D10 /* Nimble-dummy.m */,
+				000000001D00 /* Nimble-prefix.pch */,
+				000000001CD0 /* Nimble-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Nimble";
 			sourceTree = "<group>";
 		};
-		000000001F80 /* Support Files */ = {
+		000000001FB0 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000001FD0 /* Info.plist */,
-				000000001FA0 /* Quick.modulemap */,
-				000000001F90 /* Quick.xcconfig */,
-				000000001FF0 /* Quick-dummy.m */,
-				000000001FE0 /* Quick-prefix.pch */,
-				000000001FB0 /* Quick-umbrella.h */,
+				000000002000 /* Info.plist */,
+				000000001FD0 /* Quick.modulemap */,
+				000000001FC0 /* Quick.xcconfig */,
+				000000002020 /* Quick-dummy.m */,
+				000000002010 /* Quick-prefix.pch */,
+				000000001FE0 /* Quick-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Quick";
 			sourceTree = "<group>";
 		};
-		0000000020C0 /* Support Files */ = {
+		0000000020F0 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				000000002110 /* Info.plist */,
-				0000000020E0 /* URITemplate.modulemap */,
-				0000000020D0 /* URITemplate.xcconfig */,
-				000000002130 /* URITemplate-dummy.m */,
-				000000002120 /* URITemplate-prefix.pch */,
-				0000000020F0 /* URITemplate-umbrella.h */,
+				000000002140 /* Info.plist */,
+				000000002110 /* URITemplate.modulemap */,
+				000000002100 /* URITemplate.xcconfig */,
+				000000002160 /* URITemplate-dummy.m */,
+				000000002150 /* URITemplate-prefix.pch */,
+				000000002120 /* URITemplate-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/URITemplate";
 			sourceTree = "<group>";
 		};
-		0000000021F0 /* Pods-Tests */ = {
+		000000002220 /* Pods-Tests */ = {
 			isa = PBXGroup;
 			children = (
-				000000002220 /* Info.plist */,
-				000000002230 /* Pods-Tests.modulemap */,
-				000000002290 /* Pods-Tests-acknowledgements.markdown */,
-				000000002280 /* Pods-Tests-acknowledgements.plist */,
-				0000000022A0 /* Pods-Tests-dummy.m */,
-				000000002260 /* Pods-Tests-frameworks.sh */,
-				000000002270 /* Pods-Tests-resources.sh */,
-				000000002240 /* Pods-Tests-umbrella.h */,
-				000000002210 /* Pods-Tests.debug.xcconfig */,
-				000000002200 /* Pods-Tests.release.xcconfig */,
+				000000002250 /* Info.plist */,
+				000000002260 /* Pods-Tests.modulemap */,
+				0000000022C0 /* Pods-Tests-acknowledgements.markdown */,
+				0000000022B0 /* Pods-Tests-acknowledgements.plist */,
+				0000000022D0 /* Pods-Tests-dummy.m */,
+				000000002290 /* Pods-Tests-frameworks.sh */,
+				0000000022A0 /* Pods-Tests-resources.sh */,
+				000000002270 /* Pods-Tests-umbrella.h */,
+				000000002240 /* Pods-Tests.debug.xcconfig */,
+				000000002230 /* Pods-Tests.release.xcconfig */,
 			);
 			name = "Pods-Tests";
 			path = "Target Support Files/Pods-Tests";
@@ -1116,106 +1131,106 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		000000000E40 /* Headers */ = {
+		000000000E60 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000000FB0 /* Cara-umbrella.h in Headers */,
+				000000000FE0 /* Cara-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001050 /* Headers */ = {
+		000000001080 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001580 /* CryptoSwift-umbrella.h in Headers */,
+				0000000015B0 /* CryptoSwift-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001620 /* Headers */ = {
+		000000001650 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001730 /* Mockingjay-umbrella.h in Headers */,
-				0000000016D0 /* Mockingjay.h in Headers */,
+				000000001760 /* Mockingjay-umbrella.h in Headers */,
+				000000001700 /* Mockingjay.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000017D0 /* Headers */ = {
+		000000001800 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001C30 /* CwlCatchException.h in Headers */,
-				000000001C40 /* CwlMachBadInstructionHandler.h in Headers */,
-				000000001C60 /* CwlPreconditionTesting.h in Headers */,
-				000000001C00 /* DSL.h in Headers */,
-				000000001C50 /* mach_excServer.h in Headers */,
-				000000001CB0 /* Nimble-umbrella.h in Headers */,
-				000000001BF0 /* Nimble.h in Headers */,
-				000000001C10 /* NMBExceptionCapture.h in Headers */,
-				000000001C20 /* NMBStringify.h in Headers */,
+				000000001C60 /* CwlCatchException.h in Headers */,
+				000000001C70 /* CwlMachBadInstructionHandler.h in Headers */,
+				000000001C90 /* CwlPreconditionTesting.h in Headers */,
+				000000001C30 /* DSL.h in Headers */,
+				000000001C80 /* mach_excServer.h in Headers */,
+				000000001CE0 /* Nimble-umbrella.h in Headers */,
+				000000001C20 /* Nimble.h in Headers */,
+				000000001C40 /* NMBExceptionCapture.h in Headers */,
+				000000001C50 /* NMBStringify.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001D50 /* Headers */ = {
+		000000001D80 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001F40 /* QCKDSL.h in Headers */,
-				000000001FC0 /* Quick-umbrella.h in Headers */,
-				000000001F50 /* Quick.h in Headers */,
-				000000001F30 /* QuickConfiguration.h in Headers */,
-				000000001F60 /* QuickSpec.h in Headers */,
-				000000001F70 /* QuickSpecBase.h in Headers */,
+				000000001F70 /* QCKDSL.h in Headers */,
+				000000001FF0 /* Quick-umbrella.h in Headers */,
+				000000001F80 /* Quick.h in Headers */,
+				000000001F60 /* QuickConfiguration.h in Headers */,
+				000000001F90 /* QuickSpec.h in Headers */,
+				000000001FA0 /* QuickSpecBase.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000002060 /* Headers */ = {
+		000000002090 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000002100 /* URITemplate-umbrella.h in Headers */,
+				000000002130 /* URITemplate-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000021A0 /* Headers */ = {
+		0000000021D0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000002250 /* Pods-Tests-umbrella.h in Headers */,
+				000000002280 /* Pods-Tests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		000000000DF0 /* Cara */ = {
+		000000000E10 /* Cara */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000000E00 /* Build configuration list for PBXNativeTarget "Cara" */;
+			buildConfigurationList = 000000000E20 /* Build configuration list for PBXNativeTarget "Cara" */;
 			buildPhases = (
-				000000000E40 /* Headers */,
-				000000000E50 /* Sources */,
-				000000000E60 /* Frameworks */,
-				000000000E70 /* Resources */,
+				000000000E60 /* Headers */,
+				000000000E70 /* Sources */,
+				000000000E80 /* Frameworks */,
+				000000000E90 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				000000002320 /* PBXTargetDependency */,
+				000000002350 /* PBXTargetDependency */,
 			);
 			name = Cara;
 			productName = Cara;
-			productReference = 000000000E30 /* Cara.framework */;
+			productReference = 000000000E50 /* Cara.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000001000 /* CryptoSwift */ = {
+		000000001030 /* CryptoSwift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000001010 /* Build configuration list for PBXNativeTarget "CryptoSwift" */;
+			buildConfigurationList = 000000001040 /* Build configuration list for PBXNativeTarget "CryptoSwift" */;
 			buildPhases = (
-				000000001050 /* Headers */,
-				000000001060 /* Sources */,
-				000000001070 /* Frameworks */,
-				000000001080 /* Resources */,
+				000000001080 /* Headers */,
+				000000001090 /* Sources */,
+				0000000010A0 /* Frameworks */,
+				0000000010B0 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1223,36 +1238,36 @@
 			);
 			name = CryptoSwift;
 			productName = CryptoSwift;
-			productReference = 000000001040 /* CryptoSwift.framework */;
+			productReference = 000000001070 /* CryptoSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		0000000015D0 /* Mockingjay */ = {
+		000000001600 /* Mockingjay */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0000000015E0 /* Build configuration list for PBXNativeTarget "Mockingjay" */;
+			buildConfigurationList = 000000001610 /* Build configuration list for PBXNativeTarget "Mockingjay" */;
 			buildPhases = (
-				000000001620 /* Headers */,
-				000000001630 /* Sources */,
-				000000001640 /* Frameworks */,
-				000000001650 /* Resources */,
+				000000001650 /* Headers */,
+				000000001660 /* Sources */,
+				000000001670 /* Frameworks */,
+				000000001680 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				0000000023A0 /* PBXTargetDependency */,
+				0000000023D0 /* PBXTargetDependency */,
 			);
 			name = Mockingjay;
 			productName = Mockingjay;
-			productReference = 000000001610 /* Mockingjay.framework */;
+			productReference = 000000001640 /* Mockingjay.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000001780 /* Nimble */ = {
+		0000000017B0 /* Nimble */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000001790 /* Build configuration list for PBXNativeTarget "Nimble" */;
+			buildConfigurationList = 0000000017C0 /* Build configuration list for PBXNativeTarget "Nimble" */;
 			buildPhases = (
-				0000000017D0 /* Headers */,
-				0000000017E0 /* Sources */,
-				0000000017F0 /* Frameworks */,
-				000000001800 /* Resources */,
+				000000001800 /* Headers */,
+				000000001810 /* Sources */,
+				000000001820 /* Frameworks */,
+				000000001830 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1260,17 +1275,17 @@
 			);
 			name = Nimble;
 			productName = Nimble;
-			productReference = 0000000017C0 /* Nimble.framework */;
+			productReference = 0000000017F0 /* Nimble.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000001D00 /* Quick */ = {
+		000000001D30 /* Quick */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000001D10 /* Build configuration list for PBXNativeTarget "Quick" */;
+			buildConfigurationList = 000000001D40 /* Build configuration list for PBXNativeTarget "Quick" */;
 			buildPhases = (
-				000000001D50 /* Headers */,
-				000000001D60 /* Sources */,
-				000000001D70 /* Frameworks */,
-				000000001D80 /* Resources */,
+				000000001D80 /* Headers */,
+				000000001D90 /* Sources */,
+				000000001DA0 /* Frameworks */,
+				000000001DB0 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1278,17 +1293,17 @@
 			);
 			name = Quick;
 			productName = Quick;
-			productReference = 000000001D40 /* Quick.framework */;
+			productReference = 000000001D70 /* Quick.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000002010 /* URITemplate */ = {
+		000000002040 /* URITemplate */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000002020 /* Build configuration list for PBXNativeTarget "URITemplate" */;
+			buildConfigurationList = 000000002050 /* Build configuration list for PBXNativeTarget "URITemplate" */;
 			buildPhases = (
-				000000002060 /* Headers */,
-				000000002070 /* Sources */,
-				000000002080 /* Frameworks */,
-				000000002090 /* Resources */,
+				000000002090 /* Headers */,
+				0000000020A0 /* Sources */,
+				0000000020B0 /* Frameworks */,
+				0000000020C0 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1296,31 +1311,31 @@
 			);
 			name = URITemplate;
 			productName = URITemplate;
-			productReference = 000000002050 /* URITemplate.framework */;
+			productReference = 000000002080 /* URITemplate.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		000000002150 /* Pods-Tests */ = {
+		000000002180 /* Pods-Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 000000002160 /* Build configuration list for PBXNativeTarget "Pods-Tests" */;
+			buildConfigurationList = 000000002190 /* Build configuration list for PBXNativeTarget "Pods-Tests" */;
 			buildPhases = (
-				0000000021A0 /* Headers */,
-				0000000021B0 /* Sources */,
-				0000000021C0 /* Frameworks */,
-				0000000021D0 /* Resources */,
+				0000000021D0 /* Headers */,
+				0000000021E0 /* Sources */,
+				0000000021F0 /* Frameworks */,
+				000000002200 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				000000002300 /* PBXTargetDependency */,
-				000000002360 /* PBXTargetDependency */,
-				000000002380 /* PBXTargetDependency */,
-				0000000023E0 /* PBXTargetDependency */,
-				000000002400 /* PBXTargetDependency */,
-				000000002420 /* PBXTargetDependency */,
+				000000002330 /* PBXTargetDependency */,
+				000000002390 /* PBXTargetDependency */,
+				0000000023B0 /* PBXTargetDependency */,
+				000000002410 /* PBXTargetDependency */,
+				000000002430 /* PBXTargetDependency */,
+				000000002450 /* PBXTargetDependency */,
 			);
 			name = "Pods-Tests";
 			productName = "Pods-Tests";
-			productReference = 000000002190 /* Pods_Tests.framework */;
+			productReference = 0000000021C0 /* Pods_Tests.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -1344,61 +1359,61 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				000000000DF0 /* Cara */,
-				000000001000 /* CryptoSwift */,
-				0000000015D0 /* Mockingjay */,
-				000000001780 /* Nimble */,
-				000000002150 /* Pods-Tests */,
-				000000001D00 /* Quick */,
-				000000002010 /* URITemplate */,
+				000000000E10 /* Cara */,
+				000000001030 /* CryptoSwift */,
+				000000001600 /* Mockingjay */,
+				0000000017B0 /* Nimble */,
+				000000002180 /* Pods-Tests */,
+				000000001D30 /* Quick */,
+				000000002040 /* URITemplate */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		000000000E70 /* Resources */ = {
+		000000000E90 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001080 /* Resources */ = {
+		0000000010B0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001650 /* Resources */ = {
+		000000001680 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001800 /* Resources */ = {
+		000000001830 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001D80 /* Resources */ = {
+		000000001DB0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000002090 /* Resources */ = {
+		0000000020C0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000021D0 /* Resources */ = {
+		000000002200 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1408,292 +1423,296 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		000000000E50 /* Sources */ = {
+		000000000E70 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000000FF0 /* Cara-dummy.m in Sources */,
-				000000000F10 /* CodableSerializer.swift in Sources */,
-				000000000EB0 /* Configuration.swift in Sources */,
-				000000000EC0 /* Dictionary+Merge.swift in Sources */,
-				000000000F30 /* NetworkService.swift in Sources */,
-				000000000F40 /* PublicKeyPinningService.swift in Sources */,
-				000000000EE0 /* Request+URLRequest.swift in Sources */,
-				000000000EF0 /* Request.swift in Sources */,
-				000000000F00 /* RequestMethod.swift in Sources */,
-				000000000F50 /* ResponseError.swift in Sources */,
-				000000000F20 /* Serializer.swift in Sources */,
-				000000000F60 /* Service.swift in Sources */,
-				000000000ED0 /* URLResponse+Error.swift in Sources */,
+				000000001020 /* Cara-dummy.m in Sources */,
+				9D21FF0021D92A4B006EF131 /* OSLog+Request.swift in Sources */,
+				000000000F40 /* CodableSerializer.swift in Sources */,
+				000000000ED0 /* Configuration.swift in Sources */,
+				000000000EE0 /* Dictionary+Merge.swift in Sources */,
+				000000000F00 /* ConsoleLogger.swift in Sources */,
+				000000000F60 /* NetworkService.swift in Sources */,
+				000000000F70 /* PublicKeyPinningService.swift in Sources */,
+				9D21FF0421D92A70006EF131 /* Logger.swift in Sources */,
+				9D21FF0221D92A5F006EF131 /* Configuration+Logger.swift in Sources */,
+				000000000F10 /* Request+URLRequest.swift in Sources */,
+				000000000F20 /* Request.swift in Sources */,
+				000000000F30 /* RequestMethod.swift in Sources */,
+				000000000F80 /* ResponseError.swift in Sources */,
+				000000000F50 /* Serializer.swift in Sources */,
+				000000000F90 /* Service.swift in Sources */,
+				000000000EF0 /* URLResponse+Error.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001060 /* Sources */ = {
+		000000001090 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000010A0 /* AEAD.swift in Sources */,
-				0000000010B0 /* AEADChaCha20Poly1305.swift in Sources */,
-				0000000012C0 /* AES+Foundation.swift in Sources */,
-				0000000010C0 /* AES.Cryptors.swift in Sources */,
-				0000000010D0 /* AES.swift in Sources */,
-				0000000010E0 /* Array+Extension.swift in Sources */,
-				0000000012D0 /* Array+Foundation.swift in Sources */,
-				0000000010F0 /* Authenticator.swift in Sources */,
-				000000001100 /* BatchedCollection.swift in Sources */,
-				000000001110 /* Bit.swift in Sources */,
-				000000001120 /* BlockCipher.swift in Sources */,
-				000000001130 /* BlockDecryptor.swift in Sources */,
-				000000001140 /* BlockEncryptor.swift in Sources */,
-				000000001150 /* BlockMode.swift in Sources */,
-				000000001160 /* BlockModeOptions.swift in Sources */,
-				0000000012E0 /* Blowfish+Foundation.swift in Sources */,
-				000000001200 /* Blowfish.swift in Sources */,
-				000000001170 /* CBC.swift in Sources */,
-				000000001210 /* CBCMAC.swift in Sources */,
-				000000001180 /* CCM.swift in Sources */,
-				000000001190 /* CFB.swift in Sources */,
-				0000000012F0 /* ChaCha20+Foundation.swift in Sources */,
-				000000001220 /* ChaCha20.swift in Sources */,
-				000000001230 /* Checksum.swift in Sources */,
-				000000001240 /* Cipher.swift in Sources */,
-				0000000011A0 /* CipherModeWorker.swift in Sources */,
-				000000001250 /* CMAC.swift in Sources */,
-				000000001260 /* Collection+Extension.swift in Sources */,
-				000000001270 /* CompactMap.swift in Sources */,
-				000000001280 /* Cryptor.swift in Sources */,
-				000000001290 /* Cryptors.swift in Sources */,
-				0000000015C0 /* CryptoSwift-dummy.m in Sources */,
-				0000000011B0 /* CTR.swift in Sources */,
-				000000001300 /* Data+Extension.swift in Sources */,
-				0000000012A0 /* Digest.swift in Sources */,
-				0000000012B0 /* DigestType.swift in Sources */,
-				0000000011C0 /* ECB.swift in Sources */,
-				0000000011D0 /* GCM.swift in Sources */,
-				000000001350 /* Generics.swift in Sources */,
-				000000001360 /* HKDF.swift in Sources */,
-				000000001310 /* HMAC+Foundation.swift in Sources */,
-				000000001370 /* HMAC.swift in Sources */,
-				000000001380 /* Int+Extension.swift in Sources */,
-				000000001390 /* MD5.swift in Sources */,
-				0000000013A0 /* NoPadding.swift in Sources */,
-				0000000011E0 /* OFB.swift in Sources */,
-				0000000013B0 /* Operators.swift in Sources */,
-				0000000013C0 /* Padding.swift in Sources */,
-				0000000013D0 /* PBKDF1.swift in Sources */,
-				0000000013E0 /* PBKDF2.swift in Sources */,
-				0000000011F0 /* PCBC.swift in Sources */,
-				0000000013F0 /* PKCS5.swift in Sources */,
-				000000001400 /* PKCS7.swift in Sources */,
-				000000001410 /* PKCS7Padding.swift in Sources */,
-				000000001420 /* Poly1305.swift in Sources */,
-				000000001320 /* Rabbit+Foundation.swift in Sources */,
-				000000001430 /* Rabbit.swift in Sources */,
-				000000001440 /* RandomBytesSequence.swift in Sources */,
-				000000001450 /* SecureBytes.swift in Sources */,
-				000000001460 /* SHA1.swift in Sources */,
-				000000001470 /* SHA2.swift in Sources */,
-				000000001480 /* SHA3.swift in Sources */,
-				000000001490 /* StreamDecryptor.swift in Sources */,
-				0000000014A0 /* StreamEncryptor.swift in Sources */,
-				0000000014B0 /* String+Extension.swift in Sources */,
-				000000001330 /* String+FoundationExtension.swift in Sources */,
-				0000000014C0 /* UInt128.swift in Sources */,
-				0000000014D0 /* UInt16+Extension.swift in Sources */,
-				0000000014E0 /* UInt32+Extension.swift in Sources */,
-				0000000014F0 /* UInt64+Extension.swift in Sources */,
-				000000001500 /* UInt8+Extension.swift in Sources */,
-				000000001510 /* Updatable.swift in Sources */,
-				000000001340 /* Utils+Foundation.swift in Sources */,
-				000000001520 /* Utils.swift in Sources */,
-				000000001530 /* ZeroPadding.swift in Sources */,
+				0000000010D0 /* AEAD.swift in Sources */,
+				0000000010E0 /* AEADChaCha20Poly1305.swift in Sources */,
+				0000000012F0 /* AES+Foundation.swift in Sources */,
+				0000000010F0 /* AES.Cryptors.swift in Sources */,
+				000000001100 /* AES.swift in Sources */,
+				000000001110 /* Array+Extension.swift in Sources */,
+				000000001300 /* Array+Foundation.swift in Sources */,
+				000000001120 /* Authenticator.swift in Sources */,
+				000000001130 /* BatchedCollection.swift in Sources */,
+				000000001140 /* Bit.swift in Sources */,
+				000000001150 /* BlockCipher.swift in Sources */,
+				000000001160 /* BlockDecryptor.swift in Sources */,
+				000000001170 /* BlockEncryptor.swift in Sources */,
+				000000001180 /* BlockMode.swift in Sources */,
+				000000001190 /* BlockModeOptions.swift in Sources */,
+				000000001310 /* Blowfish+Foundation.swift in Sources */,
+				000000001230 /* Blowfish.swift in Sources */,
+				0000000011A0 /* CBC.swift in Sources */,
+				000000001240 /* CBCMAC.swift in Sources */,
+				0000000011B0 /* CCM.swift in Sources */,
+				0000000011C0 /* CFB.swift in Sources */,
+				000000001320 /* ChaCha20+Foundation.swift in Sources */,
+				000000001250 /* ChaCha20.swift in Sources */,
+				000000001260 /* Checksum.swift in Sources */,
+				000000001270 /* Cipher.swift in Sources */,
+				0000000011D0 /* CipherModeWorker.swift in Sources */,
+				000000001280 /* CMAC.swift in Sources */,
+				000000001290 /* Collection+Extension.swift in Sources */,
+				0000000012A0 /* CompactMap.swift in Sources */,
+				0000000012B0 /* Cryptor.swift in Sources */,
+				0000000012C0 /* Cryptors.swift in Sources */,
+				0000000015F0 /* CryptoSwift-dummy.m in Sources */,
+				0000000011E0 /* CTR.swift in Sources */,
+				000000001330 /* Data+Extension.swift in Sources */,
+				0000000012D0 /* Digest.swift in Sources */,
+				0000000012E0 /* DigestType.swift in Sources */,
+				0000000011F0 /* ECB.swift in Sources */,
+				000000001200 /* GCM.swift in Sources */,
+				000000001380 /* Generics.swift in Sources */,
+				000000001390 /* HKDF.swift in Sources */,
+				000000001340 /* HMAC+Foundation.swift in Sources */,
+				0000000013A0 /* HMAC.swift in Sources */,
+				0000000013B0 /* Int+Extension.swift in Sources */,
+				0000000013C0 /* MD5.swift in Sources */,
+				0000000013D0 /* NoPadding.swift in Sources */,
+				000000001210 /* OFB.swift in Sources */,
+				0000000013E0 /* Operators.swift in Sources */,
+				0000000013F0 /* Padding.swift in Sources */,
+				000000001400 /* PBKDF1.swift in Sources */,
+				000000001410 /* PBKDF2.swift in Sources */,
+				000000001220 /* PCBC.swift in Sources */,
+				000000001420 /* PKCS5.swift in Sources */,
+				000000001430 /* PKCS7.swift in Sources */,
+				000000001440 /* PKCS7Padding.swift in Sources */,
+				000000001450 /* Poly1305.swift in Sources */,
+				000000001350 /* Rabbit+Foundation.swift in Sources */,
+				000000001460 /* Rabbit.swift in Sources */,
+				000000001470 /* RandomBytesSequence.swift in Sources */,
+				000000001480 /* SecureBytes.swift in Sources */,
+				000000001490 /* SHA1.swift in Sources */,
+				0000000014A0 /* SHA2.swift in Sources */,
+				0000000014B0 /* SHA3.swift in Sources */,
+				0000000014C0 /* StreamDecryptor.swift in Sources */,
+				0000000014D0 /* StreamEncryptor.swift in Sources */,
+				0000000014E0 /* String+Extension.swift in Sources */,
+				000000001360 /* String+FoundationExtension.swift in Sources */,
+				0000000014F0 /* UInt128.swift in Sources */,
+				000000001500 /* UInt16+Extension.swift in Sources */,
+				000000001510 /* UInt32+Extension.swift in Sources */,
+				000000001520 /* UInt64+Extension.swift in Sources */,
+				000000001530 /* UInt8+Extension.swift in Sources */,
+				000000001540 /* Updatable.swift in Sources */,
+				000000001370 /* Utils+Foundation.swift in Sources */,
+				000000001550 /* Utils.swift in Sources */,
+				000000001560 /* ZeroPadding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001630 /* Sources */ = {
+		000000001660 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001690 /* Builders.swift in Sources */,
-				0000000016A0 /* Matchers.swift in Sources */,
-				000000001770 /* Mockingjay-dummy.m in Sources */,
-				000000001670 /* Mockingjay.swift in Sources */,
-				000000001680 /* MockingjayProtocol.swift in Sources */,
-				0000000016C0 /* MockingjayURLSessionConfiguration.m in Sources */,
-				0000000016B0 /* NSURLSessionConfiguration.swift in Sources */,
-				0000000016E0 /* XCTest.swift in Sources */,
+				0000000016C0 /* Builders.swift in Sources */,
+				0000000016D0 /* Matchers.swift in Sources */,
+				0000000017A0 /* Mockingjay-dummy.m in Sources */,
+				0000000016A0 /* Mockingjay.swift in Sources */,
+				0000000016B0 /* MockingjayProtocol.swift in Sources */,
+				0000000016F0 /* MockingjayURLSessionConfiguration.m in Sources */,
+				0000000016E0 /* NSURLSessionConfiguration.swift in Sources */,
+				000000001710 /* XCTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000017E0 /* Sources */ = {
+		000000001810 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001820 /* AdapterProtocols.swift in Sources */,
-				0000000018F0 /* AllPass.swift in Sources */,
-				000000001830 /* AssertionDispatcher.swift in Sources */,
-				000000001840 /* AssertionRecorder.swift in Sources */,
-				000000001900 /* Async.swift in Sources */,
-				000000001AF0 /* Await.swift in Sources */,
-				000000001910 /* BeAKindOf.swift in Sources */,
-				000000001920 /* BeAnInstanceOf.swift in Sources */,
-				000000001930 /* BeCloseTo.swift in Sources */,
-				000000001940 /* BeEmpty.swift in Sources */,
-				000000001950 /* BeginWith.swift in Sources */,
-				000000001960 /* BeGreaterThan.swift in Sources */,
-				000000001970 /* BeGreaterThanOrEqualTo.swift in Sources */,
-				000000001980 /* BeIdenticalTo.swift in Sources */,
-				000000001990 /* BeLessThan.swift in Sources */,
-				0000000019A0 /* BeLessThanOrEqual.swift in Sources */,
-				0000000019B0 /* BeLogical.swift in Sources */,
-				0000000019C0 /* BeNil.swift in Sources */,
-				0000000019D0 /* BeVoid.swift in Sources */,
-				0000000019E0 /* Contain.swift in Sources */,
-				0000000019F0 /* ContainElementSatisfying.swift in Sources */,
-				000000001BC0 /* CwlBadInstructionException.swift in Sources */,
-				000000001BD0 /* CwlCatchBadInstruction.swift in Sources */,
-				000000001B90 /* CwlCatchException.m in Sources */,
-				000000001B80 /* CwlCatchException.swift in Sources */,
-				000000001BE0 /* CwlDarwinDefinitions.swift in Sources */,
-				000000001BA0 /* CwlMachBadInstructionHandler.m in Sources */,
-				000000001890 /* DSL+Wait.swift in Sources */,
-				000000001B40 /* DSL.m in Sources */,
-				0000000018A0 /* DSL.swift in Sources */,
-				000000001A00 /* EndWith.swift in Sources */,
-				000000001A10 /* Equal.swift in Sources */,
-				000000001B00 /* Errors.swift in Sources */,
-				0000000018B0 /* Expectation.swift in Sources */,
-				0000000018C0 /* ExpectationMessage.swift in Sources */,
-				0000000018D0 /* Expression.swift in Sources */,
-				0000000018E0 /* FailureMessage.swift in Sources */,
-				000000001B10 /* Functional.swift in Sources */,
-				000000001A20 /* HaveCount.swift in Sources */,
-				000000001BB0 /* mach_excServer.c in Sources */,
-				000000001A30 /* Match.swift in Sources */,
-				000000001A40 /* MatcherFunc.swift in Sources */,
-				000000001A50 /* MatcherProtocols.swift in Sources */,
-				000000001A60 /* MatchError.swift in Sources */,
-				000000001CF0 /* Nimble-dummy.m in Sources */,
-				000000001850 /* NimbleEnvironment.swift in Sources */,
-				000000001860 /* NimbleXCTestHandler.swift in Sources */,
-				000000001B50 /* NMBExceptionCapture.m in Sources */,
-				000000001870 /* NMBExpectation.swift in Sources */,
-				000000001880 /* NMBObjCMatcher.swift in Sources */,
-				000000001B60 /* NMBStringify.m in Sources */,
-				000000001A70 /* PostNotification.swift in Sources */,
-				000000001A80 /* Predicate.swift in Sources */,
-				000000001A90 /* RaisesException.swift in Sources */,
-				000000001AA0 /* SatisfyAllOf.swift in Sources */,
-				000000001AB0 /* SatisfyAnyOf.swift in Sources */,
-				000000001B20 /* SourceLocation.swift in Sources */,
-				000000001B30 /* Stringers.swift in Sources */,
-				000000001AC0 /* ThrowAssertion.swift in Sources */,
-				000000001AD0 /* ThrowError.swift in Sources */,
-				000000001AE0 /* ToSucceed.swift in Sources */,
-				000000001B70 /* XCTestObservationCenter+Register.m in Sources */,
+				000000001850 /* AdapterProtocols.swift in Sources */,
+				000000001920 /* AllPass.swift in Sources */,
+				000000001860 /* AssertionDispatcher.swift in Sources */,
+				000000001870 /* AssertionRecorder.swift in Sources */,
+				000000001930 /* Async.swift in Sources */,
+				000000001B20 /* Await.swift in Sources */,
+				000000001940 /* BeAKindOf.swift in Sources */,
+				000000001950 /* BeAnInstanceOf.swift in Sources */,
+				000000001960 /* BeCloseTo.swift in Sources */,
+				000000001970 /* BeEmpty.swift in Sources */,
+				000000001980 /* BeginWith.swift in Sources */,
+				000000001990 /* BeGreaterThan.swift in Sources */,
+				0000000019A0 /* BeGreaterThanOrEqualTo.swift in Sources */,
+				0000000019B0 /* BeIdenticalTo.swift in Sources */,
+				0000000019C0 /* BeLessThan.swift in Sources */,
+				0000000019D0 /* BeLessThanOrEqual.swift in Sources */,
+				0000000019E0 /* BeLogical.swift in Sources */,
+				0000000019F0 /* BeNil.swift in Sources */,
+				000000001A00 /* BeVoid.swift in Sources */,
+				000000001A10 /* Contain.swift in Sources */,
+				000000001A20 /* ContainElementSatisfying.swift in Sources */,
+				000000001BF0 /* CwlBadInstructionException.swift in Sources */,
+				000000001C00 /* CwlCatchBadInstruction.swift in Sources */,
+				000000001BC0 /* CwlCatchException.m in Sources */,
+				000000001BB0 /* CwlCatchException.swift in Sources */,
+				000000001C10 /* CwlDarwinDefinitions.swift in Sources */,
+				000000001BD0 /* CwlMachBadInstructionHandler.m in Sources */,
+				0000000018C0 /* DSL+Wait.swift in Sources */,
+				000000001B70 /* DSL.m in Sources */,
+				0000000018D0 /* DSL.swift in Sources */,
+				000000001A30 /* EndWith.swift in Sources */,
+				000000001A40 /* Equal.swift in Sources */,
+				000000001B30 /* Errors.swift in Sources */,
+				0000000018E0 /* Expectation.swift in Sources */,
+				0000000018F0 /* ExpectationMessage.swift in Sources */,
+				000000001900 /* Expression.swift in Sources */,
+				000000001910 /* FailureMessage.swift in Sources */,
+				000000001B40 /* Functional.swift in Sources */,
+				000000001A50 /* HaveCount.swift in Sources */,
+				000000001BE0 /* mach_excServer.c in Sources */,
+				000000001A60 /* Match.swift in Sources */,
+				000000001A70 /* MatcherFunc.swift in Sources */,
+				000000001A80 /* MatcherProtocols.swift in Sources */,
+				000000001A90 /* MatchError.swift in Sources */,
+				000000001D20 /* Nimble-dummy.m in Sources */,
+				000000001880 /* NimbleEnvironment.swift in Sources */,
+				000000001890 /* NimbleXCTestHandler.swift in Sources */,
+				000000001B80 /* NMBExceptionCapture.m in Sources */,
+				0000000018A0 /* NMBExpectation.swift in Sources */,
+				0000000018B0 /* NMBObjCMatcher.swift in Sources */,
+				000000001B90 /* NMBStringify.m in Sources */,
+				000000001AA0 /* PostNotification.swift in Sources */,
+				000000001AB0 /* Predicate.swift in Sources */,
+				000000001AC0 /* RaisesException.swift in Sources */,
+				000000001AD0 /* SatisfyAllOf.swift in Sources */,
+				000000001AE0 /* SatisfyAnyOf.swift in Sources */,
+				000000001B50 /* SourceLocation.swift in Sources */,
+				000000001B60 /* Stringers.swift in Sources */,
+				000000001AF0 /* ThrowAssertion.swift in Sources */,
+				000000001B00 /* ThrowError.swift in Sources */,
+				000000001B10 /* ToSucceed.swift in Sources */,
+				000000001BA0 /* XCTestObservationCenter+Register.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000001D60 /* Sources */ = {
+		000000001D90 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000001DA0 /* Behavior.swift in Sources */,
-				000000001DB0 /* Callsite.swift in Sources */,
-				000000001E40 /* Closures.swift in Sources */,
-				000000001DC0 /* Configuration.swift in Sources */,
-				000000001DD0 /* DSL.swift in Sources */,
-				000000001DF0 /* ErrorUtility.swift in Sources */,
-				000000001E00 /* Example.swift in Sources */,
-				000000001E10 /* ExampleGroup.swift in Sources */,
-				000000001E50 /* ExampleHooks.swift in Sources */,
-				000000001E20 /* ExampleMetadata.swift in Sources */,
-				000000001E30 /* Filter.swift in Sources */,
-				000000001E60 /* HooksPhase.swift in Sources */,
-				000000001E80 /* NSBundle+CurrentTestBundle.swift in Sources */,
-				000000001E90 /* NSString+C99ExtendedIdentifier.swift in Sources */,
-				000000001EF0 /* QCKDSL.m in Sources */,
-				000000002000 /* Quick-dummy.m in Sources */,
-				000000001EE0 /* QuickConfiguration.m in Sources */,
-				000000001EA0 /* QuickSelectedTestSuiteBuilder.swift in Sources */,
-				000000001F00 /* QuickSpec.m in Sources */,
-				000000001F20 /* QuickSpecBase.m in Sources */,
-				000000001EB0 /* QuickTestSuite.swift in Sources */,
-				000000001E70 /* SuiteHooks.swift in Sources */,
-				000000001EC0 /* URL+FileName.swift in Sources */,
-				000000001DE0 /* World+DSL.swift in Sources */,
-				000000001ED0 /* World.swift in Sources */,
-				000000001F10 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
+				000000001DD0 /* Behavior.swift in Sources */,
+				000000001DE0 /* Callsite.swift in Sources */,
+				000000001E70 /* Closures.swift in Sources */,
+				000000001DF0 /* Configuration.swift in Sources */,
+				000000001E00 /* DSL.swift in Sources */,
+				000000001E20 /* ErrorUtility.swift in Sources */,
+				000000001E30 /* Example.swift in Sources */,
+				000000001E40 /* ExampleGroup.swift in Sources */,
+				000000001E80 /* ExampleHooks.swift in Sources */,
+				000000001E50 /* ExampleMetadata.swift in Sources */,
+				000000001E60 /* Filter.swift in Sources */,
+				000000001E90 /* HooksPhase.swift in Sources */,
+				000000001EB0 /* NSBundle+CurrentTestBundle.swift in Sources */,
+				000000001EC0 /* NSString+C99ExtendedIdentifier.swift in Sources */,
+				000000001F20 /* QCKDSL.m in Sources */,
+				000000002030 /* Quick-dummy.m in Sources */,
+				000000001F10 /* QuickConfiguration.m in Sources */,
+				000000001ED0 /* QuickSelectedTestSuiteBuilder.swift in Sources */,
+				000000001F30 /* QuickSpec.m in Sources */,
+				000000001F50 /* QuickSpecBase.m in Sources */,
+				000000001EE0 /* QuickTestSuite.swift in Sources */,
+				000000001EA0 /* SuiteHooks.swift in Sources */,
+				000000001EF0 /* URL+FileName.swift in Sources */,
+				000000001E10 /* World+DSL.swift in Sources */,
+				000000001F00 /* World.swift in Sources */,
+				000000001F40 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		000000002070 /* Sources */ = {
+		0000000020A0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				000000002140 /* URITemplate-dummy.m in Sources */,
-				0000000020B0 /* URITemplate.swift in Sources */,
+				000000002170 /* URITemplate-dummy.m in Sources */,
+				0000000020E0 /* URITemplate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0000000021B0 /* Sources */ = {
+		0000000021E0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0000000022B0 /* Pods-Tests-dummy.m in Sources */,
+				0000000022E0 /* Pods-Tests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		000000002300 /* PBXTargetDependency */ = {
+		000000002330 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Cara;
-			target = 000000000DF0 /* Cara */;
-			targetProxy = 0000000022F0 /* PBXContainerItemProxy */;
+			target = 000000000E10 /* Cara */;
+			targetProxy = 000000002320 /* PBXContainerItemProxy */;
 		};
-		000000002320 /* PBXTargetDependency */ = {
+		000000002350 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CryptoSwift;
-			target = 000000001000 /* CryptoSwift */;
-			targetProxy = 000000002310 /* PBXContainerItemProxy */;
+			target = 000000001030 /* CryptoSwift */;
+			targetProxy = 000000002340 /* PBXContainerItemProxy */;
 		};
-		000000002360 /* PBXTargetDependency */ = {
+		000000002390 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CryptoSwift;
-			target = 000000001000 /* CryptoSwift */;
-			targetProxy = 000000002350 /* PBXContainerItemProxy */;
+			target = 000000001030 /* CryptoSwift */;
+			targetProxy = 000000002380 /* PBXContainerItemProxy */;
 		};
-		000000002380 /* PBXTargetDependency */ = {
+		0000000023B0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Mockingjay;
-			target = 0000000015D0 /* Mockingjay */;
-			targetProxy = 000000002370 /* PBXContainerItemProxy */;
+			target = 000000001600 /* Mockingjay */;
+			targetProxy = 0000000023A0 /* PBXContainerItemProxy */;
 		};
-		0000000023A0 /* PBXTargetDependency */ = {
+		0000000023D0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = URITemplate;
-			target = 000000002010 /* URITemplate */;
-			targetProxy = 000000002390 /* PBXContainerItemProxy */;
+			target = 000000002040 /* URITemplate */;
+			targetProxy = 0000000023C0 /* PBXContainerItemProxy */;
 		};
-		0000000023E0 /* PBXTargetDependency */ = {
+		000000002410 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Nimble;
-			target = 000000001780 /* Nimble */;
-			targetProxy = 0000000023D0 /* PBXContainerItemProxy */;
+			target = 0000000017B0 /* Nimble */;
+			targetProxy = 000000002400 /* PBXContainerItemProxy */;
 		};
-		000000002400 /* PBXTargetDependency */ = {
+		000000002430 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Quick;
-			target = 000000001D00 /* Quick */;
-			targetProxy = 0000000023F0 /* PBXContainerItemProxy */;
+			target = 000000001D30 /* Quick */;
+			targetProxy = 000000002420 /* PBXContainerItemProxy */;
 		};
-		000000002420 /* PBXTargetDependency */ = {
+		000000002450 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = URITemplate;
-			target = 000000002010 /* URITemplate */;
-			targetProxy = 000000002410 /* PBXContainerItemProxy */;
+			target = 000000002040 /* URITemplate */;
+			targetProxy = 000000002440 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1819,16 +1838,15 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Release;
 		};
-		000000000E10 /* Release */ = {
+		000000000E30 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000000F80 /* Cara.xcconfig */;
+			baseConfigurationReference = 000000000FB0 /* Cara.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -1861,9 +1879,9 @@
 			};
 			name = Release;
 		};
-		000000000E20 /* Debug */ = {
+		000000000E40 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000000F80 /* Cara.xcconfig */;
+			baseConfigurationReference = 000000000FB0 /* Cara.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -1895,9 +1913,9 @@
 			};
 			name = Debug;
 		};
-		000000001020 /* Release */ = {
+		000000001050 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001550 /* CryptoSwift.xcconfig */;
+			baseConfigurationReference = 000000001580 /* CryptoSwift.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -1929,9 +1947,9 @@
 			};
 			name = Release;
 		};
-		000000001030 /* Debug */ = {
+		000000001060 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001550 /* CryptoSwift.xcconfig */;
+			baseConfigurationReference = 000000001580 /* CryptoSwift.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -1962,9 +1980,9 @@
 			};
 			name = Debug;
 		};
-		0000000015F0 /* Release */ = {
+		000000001620 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001700 /* Mockingjay.xcconfig */;
+			baseConfigurationReference = 000000001730 /* Mockingjay.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -1996,9 +2014,9 @@
 			};
 			name = Release;
 		};
-		000000001600 /* Debug */ = {
+		000000001630 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001700 /* Mockingjay.xcconfig */;
+			baseConfigurationReference = 000000001730 /* Mockingjay.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2029,9 +2047,9 @@
 			};
 			name = Debug;
 		};
-		0000000017A0 /* Release */ = {
+		0000000017D0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001C80 /* Nimble.xcconfig */;
+			baseConfigurationReference = 000000001CB0 /* Nimble.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2063,9 +2081,9 @@
 			};
 			name = Release;
 		};
-		0000000017B0 /* Debug */ = {
+		0000000017E0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001C80 /* Nimble.xcconfig */;
+			baseConfigurationReference = 000000001CB0 /* Nimble.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2096,9 +2114,9 @@
 			};
 			name = Debug;
 		};
-		000000001D20 /* Release */ = {
+		000000001D50 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001F90 /* Quick.xcconfig */;
+			baseConfigurationReference = 000000001FC0 /* Quick.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2130,9 +2148,9 @@
 			};
 			name = Release;
 		};
-		000000001D30 /* Debug */ = {
+		000000001D60 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000001F90 /* Quick.xcconfig */;
+			baseConfigurationReference = 000000001FC0 /* Quick.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2163,9 +2181,9 @@
 			};
 			name = Debug;
 		};
-		000000002030 /* Release */ = {
+		000000002060 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0000000020D0 /* URITemplate.xcconfig */;
+			baseConfigurationReference = 000000002100 /* URITemplate.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2197,9 +2215,9 @@
 			};
 			name = Release;
 		};
-		000000002040 /* Debug */ = {
+		000000002070 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0000000020D0 /* URITemplate.xcconfig */;
+			baseConfigurationReference = 000000002100 /* URITemplate.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CODE_SIGN_IDENTITY = "";
@@ -2230,9 +2248,9 @@
 			};
 			name = Debug;
 		};
-		000000002170 /* Release */ = {
+		0000000021A0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000002200 /* Pods-Tests.release.xcconfig */;
+			baseConfigurationReference = 000000002230 /* Pods-Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -2267,9 +2285,9 @@
 			};
 			name = Release;
 		};
-		000000002180 /* Debug */ = {
+		0000000021B0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 000000002210 /* Pods-Tests.debug.xcconfig */;
+			baseConfigurationReference = 000000002240 /* Pods-Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited) YES";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -2315,65 +2333,65 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000000E00 /* Build configuration list for PBXNativeTarget "Cara" */ = {
+		000000000E20 /* Build configuration list for PBXNativeTarget "Cara" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000000E20 /* Debug */,
-				000000000E10 /* Release */,
+				000000000E40 /* Debug */,
+				000000000E30 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000001010 /* Build configuration list for PBXNativeTarget "CryptoSwift" */ = {
+		000000001040 /* Build configuration list for PBXNativeTarget "CryptoSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000001030 /* Debug */,
-				000000001020 /* Release */,
+				000000001060 /* Debug */,
+				000000001050 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		0000000015E0 /* Build configuration list for PBXNativeTarget "Mockingjay" */ = {
+		000000001610 /* Build configuration list for PBXNativeTarget "Mockingjay" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000001600 /* Debug */,
-				0000000015F0 /* Release */,
+				000000001630 /* Debug */,
+				000000001620 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000001790 /* Build configuration list for PBXNativeTarget "Nimble" */ = {
+		0000000017C0 /* Build configuration list for PBXNativeTarget "Nimble" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0000000017B0 /* Debug */,
-				0000000017A0 /* Release */,
+				0000000017E0 /* Debug */,
+				0000000017D0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000001D10 /* Build configuration list for PBXNativeTarget "Quick" */ = {
+		000000001D40 /* Build configuration list for PBXNativeTarget "Quick" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000001D30 /* Debug */,
-				000000001D20 /* Release */,
+				000000001D60 /* Debug */,
+				000000001D50 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000002020 /* Build configuration list for PBXNativeTarget "URITemplate" */ = {
+		000000002050 /* Build configuration list for PBXNativeTarget "URITemplate" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000002040 /* Debug */,
-				000000002030 /* Release */,
+				000000002070 /* Debug */,
+				000000002060 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		000000002160 /* Build configuration list for PBXNativeTarget "Pods-Tests" */ = {
+		000000002190 /* Build configuration list for PBXNativeTarget "Pods-Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				000000002180 /* Debug */,
-				000000002170 /* Release */,
+				0000000021B0 /* Debug */,
+				0000000021A0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Tests/Mocks/MockedConfiguration.swift
+++ b/Example/Tests/Mocks/MockedConfiguration.swift
@@ -12,6 +12,7 @@ class MockedConfiguration: Cara.Configuration {
     var baseURL: URL?
     var headers: RequestHeaders?
     var publicKeys: PublicKeys?
+    var loggers: [Logger]?
     
     init(baseURL: URL?, headers: RequestHeaders? = nil, publicKeys: PublicKeys? = nil) {
         self.baseURL = baseURL

--- a/Example/Tests/Mocks/MockedLogger.swift
+++ b/Example/Tests/Mocks/MockedLogger.swift
@@ -1,0 +1,22 @@
+//
+//  MockedLogger.swift
+//  Tests
+//
+//  Created by Jelle Vandebeeck on 30/12/2018.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import Cara
+
+class MockedLogger: Logger {
+    private(set) var didTriggerStart: Bool = false
+    func start(urlRequest: URLRequest) {
+        didTriggerStart = true
+    }
+    
+    private(set) var didTriggerEnd: Bool = false
+    func end(urlRequest: URLRequest, urlResponse: URLResponse, metrics: URLSessionTaskMetrics, error: Error?) {
+        didTriggerEnd = true
+    }
+}

--- a/Example/Tests/Mocks/MockedPublicKeyPinningService.swift
+++ b/Example/Tests/Mocks/MockedPublicKeyPinningService.swift
@@ -1,0 +1,14 @@
+//
+//  MockedPublicKeyPinningService.swift
+//  Tests
+//
+//  Created by Jelle Vandebeeck on 30/12/2018.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import Foundation
+
+@testable import Cara
+
+class MockedPublicKeyPinningService: PublicKeyPinningService {
+}

--- a/Example/Tests/Specs/Service/NetworkServiceSpec.swift
+++ b/Example/Tests/Specs/Service/NetworkServiceSpec.swift
@@ -1,0 +1,92 @@
+//
+//  NetworkServiceSpec.swift
+//  Tests
+//
+//  Created by Jelle Vandebeeck on 30/12/2018.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import Quick
+import Nimble
+import Mockingjay
+
+@testable import Cara
+
+class NetworkServiceSpec: QuickSpec {
+    // swiftlint:disable function_body_length
+    override func spec() {
+        describe("NetworkService") {
+            var service: NetworkService!
+            var configuration: MockedConfiguration!
+            var pinningService: MockedPublicKeyPinningService!
+            beforeEach {
+                configuration = MockedConfiguration(baseURL: URL(string: "https://relative.com/")!)
+                pinningService = MockedPublicKeyPinningService(configuration: configuration)
+                service = NetworkService(configuration: configuration, pinningService: pinningService)
+            }
+            
+            context("logger") {
+                var loggerOne: MockedLogger!
+                var loggerTwo: MockedLogger!
+                beforeEach {
+                    loggerOne = MockedLogger()
+                    loggerTwo = MockedLogger()
+                    configuration.loggers = [loggerOne, loggerTwo]
+                }
+                
+                it("should trigger the start on all the configuration") {
+                    self.stub(http(.get, uri: "https://relative.com/request"), delay: 0.1, http(200))
+                    let request = URLRequest(url: URL(string: "https://relative.com/request")!)
+                    
+                    service.execute(request, with: MockedSerializer()) { _ in }
+                    expect(loggerOne.didTriggerStart) == true
+                    expect(loggerTwo.didTriggerStart) == true
+                }
+                
+                it("should trigger the end on all the configuration") {
+                    self.stub(http(.get, uri: "https://relative.com/request"), delay: 0.1, http(200))
+                    let request = URLRequest(url: URL(string: "https://relative.com/request")!)
+                    
+                    waitUntil { done in
+                        service.execute(request, with: MockedSerializer()) { _ in
+                            done()
+                        }
+                    }
+                    expect(loggerOne.didTriggerEnd) == true
+                    expect(loggerTwo.didTriggerEnd) == true
+                }
+            }
+            
+            context("threading") {
+                it("should return on the main queue") {
+                    self.stub(http(.get, uri: "https://relative.com/request"), http(200))
+                    let request = URLRequest(url: URL(string: "https://relative.com/request")!)
+                    
+                    waitUntil { done in
+                        DispatchQueue.main.async {
+                            service.execute(request, with: MockedSerializer()) { _ in
+                                expect(Thread.isMainThread) == true
+                                done()
+                            }
+                        }
+                    }
+                }
+                
+                it("should not return on the global queue") {
+                    self.stub(http(.get, uri: "https://relative.com/request"), http(200))
+                    let request = URLRequest(url: URL(string: "https://relative.com/request")!)
+                    
+                    waitUntil { done in
+                        DispatchQueue.global(qos: .utility).async {
+                            service.execute(request, with: MockedSerializer()) { _ in
+                                expect(Thread.isMainThread) == false
+                                done()
+                            }
+                        }
+                        
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Example/Tests/Specs/Service/ServiceSpec.swift
+++ b/Example/Tests/Specs/Service/ServiceSpec.swift
@@ -22,38 +22,6 @@ class ServiceSpec: QuickSpec {
                 service = Service(configuration: configuration)
             }
             
-            context("threading") {
-                it("should return on the main queue") {
-                    self.stub(http(.get, uri: "https://relative.com/request"), http(200))
-                    
-                    let request = MockedRequest(url: URL(string: "request"))
-                    waitUntil { done in
-                        DispatchQueue.main.async {
-                            service.execute(request, with: MockedSerializer()) { _ in
-                                expect(Thread.isMainThread) == true
-                                done()
-                            }
-                        }
-                        
-                    }
-                }
-                
-                it("should not return on the global queue") {
-                    self.stub(http(.get, uri: "https://relative.com/request"), http(200))
-                    
-                    let request = MockedRequest(url: URL(string: "request"))
-                    waitUntil { done in
-                        DispatchQueue.global(qos: .utility).async {
-                            service.execute(request, with: MockedSerializer()) { _ in
-                                expect(Thread.isMainThread) == false
-                                done()
-                            }
-                        }
-                        
-                    }
-                }
-            }
-            
             context("request") {
                 it("should execute an absolute request") {
                     self.stub(http(.get, uri: "https://absolute.com/request"), http(200))

--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -16,4 +16,6 @@ public protocol Configuration {
     var headers: RequestHeaders? { get }
     /// Set the public keys for the hosts.
     var publicKeys: PublicKeys? { get }
+    /// Set the loggers when you want to receive more information on the requests.
+    var loggers: [Logger]? { get }
 }

--- a/Sources/Logger/Configuration+Logger.swift
+++ b/Sources/Logger/Configuration+Logger.swift
@@ -1,0 +1,18 @@
+//
+//  Configuration+Logger.swift
+//  Cara
+//
+//  Created by Jelle Vandebeeck on 30/12/2018.
+//
+
+import Foundation
+
+extension Configuration {
+    func start(urlRequest: URLRequest) {
+        loggers?.forEach { $0.start(urlRequest: urlRequest) }
+    }
+    
+    func end(urlRequest: URLRequest, urlResponse: URLResponse?, error: Error?) {
+        loggers?.forEach { $0.end(urlRequest: urlRequest, urlResponse: urlResponse, error: error) }
+    }
+}

--- a/Sources/Logger/Configuration+Logger.swift
+++ b/Sources/Logger/Configuration+Logger.swift
@@ -12,7 +12,7 @@ extension Configuration {
         loggers?.forEach { $0.start(urlRequest: urlRequest) }
     }
     
-    func end(urlRequest: URLRequest, urlResponse: URLResponse?, error: Error?) {
-        loggers?.forEach { $0.end(urlRequest: urlRequest, urlResponse: urlResponse, error: error) }
+    func end(urlRequest: URLRequest, urlResponse: URLResponse, metrics: URLSessionTaskMetrics, error: Error?) {
+        loggers?.forEach { $0.end(urlRequest: urlRequest, urlResponse: urlResponse, metrics: metrics, error: error) }
     }
 }

--- a/Sources/Logger/ConsoleLogger.swift
+++ b/Sources/Logger/ConsoleLogger.swift
@@ -21,27 +21,33 @@ extension ConsoleLogger: Logger {
         os_log("☁️ %{public}@: %{public}@", log: OSLog.request, type: .info, method, url.absoluteString)
     }
     
-    public func end(urlRequest: URLRequest, urlResponse: URLResponse?, error: Error?) {
+    public func end(urlRequest: URLRequest, urlResponse: URLResponse, metrics: URLSessionTaskMetrics, error: Error?) {
         guard
             let method = urlRequest.httpMethod,
             let httpResponse = urlResponse as? HTTPURLResponse,
-            let url = urlRequest.url else { return }
+            let url = urlRequest.url,
+            let transactionMetric = metrics.transactionMetrics.first,
+            let requestEndDate = transactionMetric.requestEndDate,
+            let domainLookupStartDate = transactionMetric.domainLookupStartDate else { return }
         
+        let totalDuration = requestEndDate.timeIntervalSince(domainLookupStartDate)
         if let error = error {
-            os_log("⛈ %{public}@ %i: %{public}@\nError: %{public}@",
+            os_log("⛈ %{public}@ %i: %{public}@ 💥 %{public}@ ⏳ %.3fms",
                    log: OSLog.request,
                    type: .info,
                    method,
                    httpResponse.statusCode,
                    url.absoluteString,
-                   error.localizedDescription)
+                   error.localizedDescription,
+                   totalDuration)
         } else {
-            os_log("☀️ %{public}@ %i: %{public}@",
+            os_log("☀️ %{public}@ %i: %{public}@ ⏳ %.3fms",
                    log: OSLog.request,
                    type: .info,
                    method,
                    httpResponse.statusCode,
-                   url.absoluteString)
+                   url.absoluteString,
+                   totalDuration)
         }
     }
 }

--- a/Sources/Logger/ConsoleLogger.swift
+++ b/Sources/Logger/ConsoleLogger.swift
@@ -28,7 +28,7 @@ extension ConsoleLogger: Logger {
             let url = urlRequest.url,
             let transactionMetric = metrics.transactionMetrics.first,
             let requestEndDate = transactionMetric.requestEndDate,
-            let domainLookupStartDate = transactionMetric.domainLookupStartDate else { return }
+            let domainLookupStartDate =  transactionMetric.domainLookupStartDate else { return }
         
         let totalDuration = requestEndDate.timeIntervalSince(domainLookupStartDate)
         if let error = error {

--- a/Sources/Logger/ConsoleLogger.swift
+++ b/Sources/Logger/ConsoleLogger.swift
@@ -1,0 +1,47 @@
+//
+//  Logger.swift
+//  Cara
+//
+//  Created by Jelle Vandebeeck on 30/12/2018.
+//
+
+import os
+
+/// The `Console` logger logs some minimal request information to the console.
+public class ConsoleLogger {
+    public init() {
+    }
+}
+
+extension ConsoleLogger: Logger {
+    public func start(urlRequest: URLRequest) {
+        guard
+            let method = urlRequest.httpMethod,
+            let url = urlRequest.url else { return }
+        os_log("☁️ %{public}@: %{public}@", log: OSLog.request, type: .info, method, url.absoluteString)
+    }
+    
+    public func end(urlRequest: URLRequest, urlResponse: URLResponse?, error: Error?) {
+        guard
+            let method = urlRequest.httpMethod,
+            let httpResponse = urlResponse as? HTTPURLResponse,
+            let url = urlRequest.url else { return }
+        
+        if let error = error {
+            os_log("⛈ %{public}@ %i: %{public}@\nError: %{public}@",
+                   log: OSLog.request,
+                   type: .info,
+                   method,
+                   httpResponse.statusCode,
+                   url.absoluteString,
+                   error.localizedDescription)
+        } else {
+            os_log("☀️ %{public}@ %i: %{public}@",
+                   log: OSLog.request,
+                   type: .info,
+                   method,
+                   httpResponse.statusCode,
+                   url.absoluteString)
+        }
+    }
+}

--- a/Sources/Logger/Logger.swift
+++ b/Sources/Logger/Logger.swift
@@ -9,8 +9,15 @@ import Foundation
 
 /// A class can conform to this protocol in order to get more information before and after a request.
 public protocol Logger {
-    /// Trigger before a request is fired.
+    /// The `start` function is triggered just before a request if fired.
+    ///
+    /// - parameters urlRequest: The request that is will be executed.
     func start(urlRequest: URLRequest)
-    /// Trigger after a request completed.
-    func end(urlRequest: URLRequest, urlResponse: URLResponse?, error: Error?)
+    /// The `end` function is triggered just after the request finised collecting the metrics.
+    ///
+    /// - parameters urlRequest: The request that is was executed after redirection.
+    /// - parameters urlResponse: The response of the request.
+    /// - parameters metrics: The metrics for the request.
+    /// - parameters error: The error is an error occured.
+    func end(urlRequest: URLRequest, urlResponse: URLResponse, metrics: URLSessionTaskMetrics, error: Error?)
 }

--- a/Sources/Logger/Logger.swift
+++ b/Sources/Logger/Logger.swift
@@ -1,0 +1,16 @@
+//
+//  Logger.swift
+//  Cara
+//
+//  Created by Jelle Vandebeeck on 30/12/2018.
+//
+
+import Foundation
+
+/// A class can conform to this protocol in order to get more information before and after a request.
+public protocol Logger {
+    /// Trigger before a request is fired.
+    func start(urlRequest: URLRequest)
+    /// Trigger after a request completed.
+    func end(urlRequest: URLRequest, urlResponse: URLResponse?, error: Error?)
+}

--- a/Sources/Logger/OSLog+Request.swift
+++ b/Sources/Logger/OSLog+Request.swift
@@ -1,0 +1,22 @@
+//
+//  OSLog+Request.swift
+//  Cara
+//
+//  Created by Jelle Vandebeeck on 30/12/2018.
+//
+
+import os
+
+extension OSLog {
+    
+    // MARK: - Categories
+    
+    static let request = OSLog(category: "Request")
+    
+    // MARK: - Init
+    
+    private convenience init(category: String, bundle: Bundle = Bundle.main) {
+        let identifier = bundle.infoDictionary?["CFBundleIdentifier"] as? String
+        self.init(subsystem: (identifier ?? "").appending(".logs"), category: category)
+    }
+}

--- a/Sources/Service/NetworkService.swift
+++ b/Sources/Service/NetworkService.swift
@@ -23,6 +23,7 @@ class NetworkService: NSObject {
     
     // MARK: - Execute
     
+    @discardableResult
     func execute<S: Serializer>(_ urlRequest: URLRequest,
                                 with serializer: S,
                                 completion: @escaping (_ response: S.Response) -> Void) -> URLSessionDataTask {

--- a/Sources/Service/PublicKeyPinningService.swift
+++ b/Sources/Service/PublicKeyPinningService.swift
@@ -57,9 +57,7 @@ class PublicKeyPinningService {
                 keyWithHeader.append(publicKeyData as Data)
                 let sha256 = keyWithHeader.sha256()
                 // When the public keys don't match continue to the next certificate.
-                guard sha256.base64EncodedString() == publicKeyString else { continue }
-                
-                print("🔑 Handle public key pinning for host", host)
+                guard sha256.base64EncodedString() == publicKeyString else { continue }                
                 completionHandler(.useCredential, URLCredential(trust: secTrust))
                 return
             }


### PR DESCRIPTION
Make it possible to add more loggers to the service layer.

You can add them through the following configuration:

```swift
var loggers: [Logger]? {
    return [ConsoleLogger()]
}
```

The ConsoleLogger is a default provided one, you do have to pass them through the configuration though.

More information will be passed in the next PR where the readme will be updated. (I forgot 🤦‍♂️)