### PR TITLE
Correctly append the query to an existing query.

### DIFF
--- a/Example/Tests/Specs/Request/RequestSpec.swift
+++ b/Example/Tests/Specs/Request/RequestSpec.swift
@@ -46,6 +46,21 @@ class RequestSpec: QuickSpec {
                     _ = try request.makeURLRequest(with: configuration)
                 }.to(throwError(ResponseError.invalidURL))
             }
+            
+            it("should correctly set the url when a query is given within a relative url") {
+                let url = URL(string: "request?key=value")!
+                let request = MockedRequest(url: url, query: ["jake": "the_snake"])
+                let urlRequest = try? request.makeURLRequest(with: configuration)
+                expect(urlRequest?.url?.absoluteString) == "https://relative.com/request?key=value&jake=the_snake"
+            }
+            
+            it("should correctly set the url when a query is given with a relative url") {
+                var urlComponents = URLComponents(string: "request")!
+                urlComponents.queryItems = [URLQueryItem(name: "key", value: "value")]
+                let request = MockedRequest(url: urlComponents.url!, query: ["jake": "the_snake"])
+                let urlRequest = try? request.makeURLRequest(with: configuration)
+                expect(urlRequest?.url?.absoluteString) == "https://relative.com/request?key=value&jake=the_snake"
+            }
         }
         
         context("method") {
@@ -86,7 +101,7 @@ class RequestSpec: QuickSpec {
             }
         }
         
-        context("headers") {
+        context("query") {
             it("should have no query parameters") {
                 let request = MockedRequest(url: URL(string: "request"))
                 let urlRequest = try? request.makeURLRequest(with: configuration)
@@ -101,6 +116,15 @@ class RequestSpec: QuickSpec {
             
             it("should have multiple query parameters") {
                 let request = MockedRequest(url: URL(string: "request"), query: ["key": "value", "jake": "the_snake"])
+                let urlRequest = try? request.makeURLRequest(with: configuration)
+                expect(urlRequest?.url?.query).to(contain("key=value"))
+                expect(urlRequest?.url?.query).to(contain("jake=the_snake"))
+            }
+            
+            it("should append extra query paramaters") {
+                var urlComponents = URLComponents(string: "request")!
+                urlComponents.queryItems = [URLQueryItem(name: "key", value: "value")]
+                let request = MockedRequest(url: urlComponents.url!, query: ["jake": "the_snake"])
                 let urlRequest = try? request.makeURLRequest(with: configuration)
                 expect(urlRequest?.url?.query).to(contain("key=value"))
                 expect(urlRequest?.url?.query).to(contain("jake=the_snake"))

--- a/Sources/Request/Request+URLRequest.swift
+++ b/Sources/Request/Request+URLRequest.swift
@@ -21,13 +21,31 @@ extension Request {
     private func makeURL(with configuration: Configuration) throws -> URL {
         // A correct url should be set. And when this is the case we alreay try to append the query
         // to this url.
-        guard let url = url else { throw ResponseError.invalidURL }
-        // When the url is an absolure url, just use this url.
-        guard url.host == nil else { return url.appendingQuery(from: self) }
-        // When the url is a relative url we should have a base url defined.
-        guard let baseURL = configuration.baseURL else { throw ResponseError.invalidURL }
+        guard
+            let url = url,
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw ResponseError.invalidURL
+        }
+        
+        var requestURL: URL
+        if components.host != nil {
+            // When the url is an absolure url, just use this url.
+            requestURL = url
+        } else if let baseURL = configuration.baseURL {
+            // When the url is a relative url we should have a base url defined.
+            let newURL = baseURL.appendingPathComponent(components.path)
+            requestURL = newURL
+        } else {
+            throw ResponseError.invalidURL
+        }
+        
+        // Append the original query paramters to the new request url.
+        var requestComponents = URLComponents(url: requestURL, resolvingAgainstBaseURL: false)
+        requestComponents?.queryItems = components.queryItems
+        guard let correctURL = requestComponents?.url else { throw ResponseError.invalidURL }
+        
         // Return the relative url appended to the base url.
-        return baseURL.appendingPathComponent(url.absoluteString).appendingQuery(from: self)
+        return correctURL.appendingQuery(from: self)
     }
     
     private func makeHeaders(with configuration: Configuration) -> RequestHeaders? {
@@ -53,8 +71,18 @@ extension Request {
 
 fileprivate extension URL {
     func appendingQuery(from request: Request) -> URL {
-        guard var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return self }
-        urlComponents.queryItems = request.query?.map { URLQueryItem(name: $0.key, value: $0.value) }
+        guard
+            let query = request.query,
+            var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return self }
+        
+        let queryItems: [URLQueryItem] = query.map { URLQueryItem(name: $0.key, value: $0.value) }
+        // When the initial url doesn't contain query items we set the request's items. Otherwise we append the
+        // items to the existing ones.
+        if urlComponents.queryItems == nil {
+            urlComponents.queryItems = queryItems
+        } else {
+            urlComponents.queryItems?.append(contentsOf: queryItems)
+        }
         return urlComponents.url ?? self
     }
 }


### PR DESCRIPTION
When the url property contains `some_request?ke=value` than this value was removed when constructing the request. 

But that is fixed! 🎉