### PR TITLE
Pass data to the interceptor.

### DIFF
--- a/Example/Tests/Mocks/MockedInterceptor.swift
+++ b/Example/Tests/Mocks/MockedInterceptor.swift
@@ -10,7 +10,7 @@ import Cara
 
 class MockedInterceptor: Interceptor {
     var interceptHandle: ((_ error: ResponseError, _ retry: @escaping () -> Void) -> Bool)?
-    func intercept(_ error: ResponseError, retry: @escaping () -> Void) -> Bool {
+    func intercept(_ error: ResponseError, data: Data?, retry: @escaping () -> Void) -> Bool {
         return interceptHandle?(error, retry) ?? false
     }
 }

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Once this is done you are good to go. For more information on what configuration
 
 An intercept will _intercept_ the request when an error of type `ResponseError` occurs.
 
-When this happens `intercept(_:retry:)` will be triggered and you should return `true` or `false` to indicate if you want the normal response flow to stop. When you stop the flow it will be possible to retry the request by calling the `retry()` block.
+When this happens `intercept(_:data:retry:)` will be triggered and you should return `true` or `false` to indicate if you want the normal response flow to stop. When you stop the flow it will be possible to retry the request by calling the `retry()` block.
 
 ```swift
-func intercept(_ error: ResponseError, retry: @escaping () -> Void) -> Bool {
+func intercept(_ error: ResponseError, data: Data?, retry: @escaping () -> Void) -> Bool {
     if error == .unauthorized {
         // Execute the retry block after one second. The failed request will be retried.
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: retry)

--- a/Sources/Configuration/Interceptor.swift
+++ b/Sources/Configuration/Interceptor.swift
@@ -13,9 +13,10 @@ public protocol Interceptor {
     /// This function is triggered when a response error is triggered.
     ///
     /// - parameter error: The error that triggers the interceptor.
+    /// - parameter data: The body's data object if available.
     /// - parameter retry: The block you should trigger to retry the failed request.
     ///
     /// - returns: Return if you want the response processing to be intercepted so that
     /// the normal flow (with completion handler) is stopped.
-    func intercept(_ error: ResponseError, retry: @escaping () -> Void) -> Bool
+    func intercept(_ error: ResponseError, data: Data?, retry: @escaping () -> Void) -> Bool
 }

--- a/Sources/Service/NetworkService.swift
+++ b/Sources/Service/NetworkService.swift
@@ -41,7 +41,7 @@ class NetworkService: NSObject {
             if
                 let responseError = urlResponse?.responseError,
                 let interceptor = self?.interceptor,
-                interceptor.intercept(responseError, retry: retry) {
+                interceptor.intercept(responseError, data: data, retry: retry) {
                 return
             }
             


### PR DESCRIPTION
In some cases you may want to parse the data even when a response is intercepted.