### PR TITLE
Pass the retry count of the current request to the interceptor.

### DIFF
--- a/Example/Tests/Mocks/MockedInterceptor.swift
+++ b/Example/Tests/Mocks/MockedInterceptor.swift
@@ -10,7 +10,9 @@ import Cara
 
 class MockedInterceptor: Interceptor {
     var interceptHandle: ((_ error: ResponseError, _ retry: @escaping () -> Void) -> Bool)?
-    func intercept(_ error: ResponseError, data: Data?, retry: @escaping () -> Void) -> Bool {
+    var didReceiveRetryCount: UInt?
+    func intercept(_ error: ResponseError, data: Data?, retryCount: UInt, retry: @escaping () -> Void) -> Bool {
+        didReceiveRetryCount = retryCount
         return interceptHandle?(error, retry) ?? false
     }
 }

--- a/Example/Tests/Specs/Service/NetworkServiceSpec.swift
+++ b/Example/Tests/Specs/Service/NetworkServiceSpec.swift
@@ -38,7 +38,7 @@ class NetworkServiceSpec: QuickSpec {
                     self.stub(http(.get, uri: "https://relative.com/request"), delay: 0.1, http(200))
                     let request = URLRequest(url: URL(string: "https://relative.com/request")!)
                     
-                    service.execute(request, with: MockedSerializer(), retry: {}, completion: { _ in })
+                    service.execute(request, with: MockedSerializer(), retryCount: 0, retry: {}, completion: { _ in })
                     expect(loggerOne.didTriggerStartRequest).toNot(beNil())
                     expect(loggerTwo.didTriggerStartRequest).toNot(beNil())
                 }
@@ -48,7 +48,7 @@ class NetworkServiceSpec: QuickSpec {
                     let request = URLRequest(url: URL(string: "https://relative.com/request")!)
                     
                     waitUntil { done in
-                        service.execute(request, with: MockedSerializer(), retry: {}, completion: { _ in
+                        service.execute(request, with: MockedSerializer(), retryCount: 0, retry: {}, completion: { _ in
                             done()
                         })
                     }
@@ -70,7 +70,7 @@ class NetworkServiceSpec: QuickSpec {
                     service.interceptor = interceptor
                     
                     waitUntil { done in
-                        service.execute(one, with: MockedSerializer(), retry: {}, completion: { _ in
+                        service.execute(one, with: MockedSerializer(), retryCount: 0, retry: {}, completion: { _ in
                             done()
                         })
                     }
@@ -88,7 +88,7 @@ class NetworkServiceSpec: QuickSpec {
                     service.interceptor = interceptor
                     
                     waitUntil { done in
-                        service.execute(one, with: MockedSerializer(), retry: {
+                        service.execute(one, with: MockedSerializer(), retryCount: 0, retry: {
                             done()
                         }, completion: { _ in })
                     }
@@ -102,7 +102,10 @@ class NetworkServiceSpec: QuickSpec {
                     
                     waitUntil { done in
                         DispatchQueue.main.async {
-                            service.execute(request, with: MockedSerializer(), retry: {}, completion: { _ in
+                            service.execute(request,
+                                            with: MockedSerializer(),
+                                            retryCount: 0,
+                                            retry: {}, completion: { _ in
                                 expect(Thread.isMainThread) == true
                                 done()
                             })
@@ -116,7 +119,11 @@ class NetworkServiceSpec: QuickSpec {
                     
                     waitUntil { done in
                         DispatchQueue.global(qos: .utility).async {
-                            service.execute(request, with: MockedSerializer(), retry: {}, completion: { _ in
+                            service.execute(request,
+                                            with: MockedSerializer(),
+                                            retryCount: 0,
+                                            retry: {},
+                                            completion: { _ in
                                 expect(Thread.isMainThread) == false
                                 done()
                             })

--- a/Sources/Configuration/Interceptor.swift
+++ b/Sources/Configuration/Interceptor.swift
@@ -14,9 +14,10 @@ public protocol Interceptor {
     ///
     /// - parameter error: The error that triggers the interceptor.
     /// - parameter data: The body's data object if available.
+    /// - parameter retryCount: The number of times the same request has been retried.
     /// - parameter retry: The block you should trigger to retry the failed request.
     ///
     /// - returns: Return if you want the response processing to be intercepted so that
     /// the normal flow (with completion handler) is stopped.
-    func intercept(_ error: ResponseError, data: Data?, retry: @escaping () -> Void) -> Bool
+    func intercept(_ error: ResponseError, data: Data?, retryCount: UInt, retry: @escaping () -> Void) -> Bool
 }

--- a/Sources/Service/NetworkService.swift
+++ b/Sources/Service/NetworkService.swift
@@ -26,6 +26,7 @@ class NetworkService: NSObject {
     @discardableResult
     func execute<S: Serializer>(_ urlRequest: URLRequest,
                                 with serializer: S,
+                                retryCount: UInt,
                                 retry: @escaping () -> Void,
                                 completion: @escaping (_ response: S.Response) -> Void) -> URLSessionDataTask {
         // Get the originating queue.
@@ -41,7 +42,7 @@ class NetworkService: NSObject {
             if
                 let responseError = urlResponse?.responseError,
                 let interceptor = self?.interceptor,
-                interceptor.intercept(responseError, data: data, retry: retry) {
+                interceptor.intercept(responseError, data: data, retryCount: retryCount, retry: retry) {
                 return
             }
             


### PR DESCRIPTION
We sometimes want to know the number of times a request has been tried, this will now be passed to the interceptor.