### PR TITLE
Bypass interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ func intercept(_ error: ResponseError, data: Data?, retry: @escaping () -> Void)
 }
 ```
 
+⚠️ The `Request` can define it it can be intercepted with the `isInterceptable` property. This should always be true in most cases. But, for example, the refresh tokens request should not be intercepted.
+
 ### Trigger a Request
 
 In order to trigger a request you have to do 2 things:

--- a/Sources/Request/Request+Defaults.swift
+++ b/Sources/Request/Request+Defaults.swift
@@ -27,4 +27,8 @@ extension Request {
     public var networkServiceType: NSURLRequest.NetworkServiceType {
         return .default
     }
+    
+    public var isInterceptable: Bool {
+        return true
+    }
 }

--- a/Sources/Request/Request.swift
+++ b/Sources/Request/Request.swift
@@ -29,4 +29,7 @@ public protocol Request {
     var cachePolicy: URLRequest.CachePolicy { get }
     /// Set the network service type to prioritize the request.
     var networkServiceType: NSURLRequest.NetworkServiceType { get }
+    /// Define if the request can be intercepted. Make sure this is set to false when you are for example
+    /// refreshing the tokens. The refresh request should not be interceptable.
+    var isInterceptable: Bool { get }
 }

--- a/Sources/Service/NetworkService.swift
+++ b/Sources/Service/NetworkService.swift
@@ -24,8 +24,10 @@ class NetworkService: NSObject {
     // MARK: - Execute
     
     @discardableResult
+    // swiftlint:disable function_parameter_count
     func execute<S: Serializer>(_ urlRequest: URLRequest,
                                 with serializer: S,
+                                isInterceptable: Bool,
                                 retryCount: UInt,
                                 retry: @escaping () -> Void,
                                 completion: @escaping (_ response: S.Response) -> Void) -> URLSessionDataTask {
@@ -42,6 +44,7 @@ class NetworkService: NSObject {
             if
                 let responseError = urlResponse?.responseError,
                 let interceptor = self?.interceptor,
+                isInterceptable,
                 interceptor.intercept(responseError, data: data, retryCount: retryCount, retry: retry) {
                 return
             }

--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -56,7 +56,11 @@ open class Service {
         do {
             // Create the request.
             let urlRequest = try request.makeURLRequest(with: configuration)
-            return networkService.execute(urlRequest, with: serializer, retryCount: retryCount, retry: { [weak self] in
+            return networkService.execute(urlRequest,
+                                          with: serializer,
+                                          isInterceptable: request.isInterceptable,
+                                          retryCount: retryCount,
+                                          retry: { [weak self] in
                 self?.execute(request, with: serializer, retryCount: retryCount + 1, completion: completion)
             }, completion: completion)
         } catch {


### PR DESCRIPTION
There was a glitch in the system...

1. The initial request is intercepted
2. The refresh request is triggered and is intercepted
3. Nothing happens

We should be able to define is a request can be intercepted or not.