### PR TITLE
Invalidate the session correctly.

### DIFF
--- a/Sources/Service/NetworkService.swift
+++ b/Sources/Service/NetworkService.swift
@@ -56,6 +56,8 @@ class NetworkService: NSObject {
             self?.complete(on: executionQueue, block: { completion(response) })
         }
         task.resume()
+        // This causes the delegate to be released correctly.
+        session.finishTasksAndInvalidate()
         return task
     }
     


### PR DESCRIPTION
When creating an `URLSession` the `delegate` is retained. This causes the delegate to never be released resulting in a memory leak.