### PR TITLE
Pass the request to the configuration headers.

### DIFF
--- a/Cara/Cara.xcodeproj/project.pbxproj
+++ b/Cara/Cara.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 				TargetAttributes = {
 					9D551C702273749400DDD584 = {
 						CreatedOnToolsVersion = 10.2.1;
+						LastSwiftMigration = 1130;
 					};
 					9D551C87227374FF00DDD584 = {
 						CreatedOnToolsVersion = 10.2.1;
@@ -281,6 +282,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 9D551C672273749400DDD584;
 			productRefGroup = 9D551C722273749400DDD584 /* Products */;
@@ -508,7 +510,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icapps.cara.Cara;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -535,7 +537,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icapps.cara.Cara;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Cara/Cara.xcodeproj/xcshareddata/xcschemes/Cara Tv.xcscheme
+++ b/Cara/Cara.xcodeproj/xcshareddata/xcschemes/Cara Tv.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:Cara.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Cara/Cara.xcodeproj/xcshareddata/xcschemes/Cara.xcscheme
+++ b/Cara/Cara.xcodeproj/xcshareddata/xcschemes/Cara.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:Cara.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -174,7 +174,6 @@
 				DF61D7691CFD97C63E743260 /* Pods-Tests.debug.xcconfig */,
 				2B992619292F276108EA57B6 /* Pods-Tests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -222,7 +221,7 @@
 				TargetAttributes = {
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -479,7 +478,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -498,7 +497,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACE41AFB9204008FA782"
+            BuildableName = "Tests.xctest"
+            BlueprintName = "Tests"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -52,17 +61,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "607FACE41AFB9204008FA782"
-            BuildableName = "Tests.xctest"
-            BlueprintName = "Tests"
-            ReferencedContainer = "container:Example.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -83,8 +81,6 @@
             ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 			dependencies = (
 			);
 			name = SwiftLint;
+			productName = SwiftLint;
 		};
 /* End PBXAggregateTarget section */
 
@@ -193,7 +194,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0000000000F0 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		0000000000F0 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		000000000110 /* Mockingjay.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Mockingjay.h; path = Sources/Mockingjay/Mockingjay.h; sourceTree = "<group>"; };
 		000000000120 /* Mockingjay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Mockingjay.swift; path = Sources/Mockingjay/Mockingjay.swift; sourceTree = "<group>"; };
 		000000000130 /* MockingjayProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockingjayProtocol.swift; path = Sources/Mockingjay/MockingjayProtocol.swift; sourceTree = "<group>"; };
@@ -265,7 +266,7 @@
 		000000000560 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
 		000000000570 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
 		000000000580 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
-		000000000590 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		000000000590 /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
 		0000000005A0 /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
 		0000000005B0 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
 		0000000005C0 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
@@ -302,7 +303,7 @@
 		0000000007B0 /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
 		0000000007C0 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickSpecBase/QuickSpecBase.m; sourceTree = "<group>"; };
 		0000000007D0 /* URITemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URITemplate.swift; path = Sources/URITemplate.swift; sourceTree = "<group>"; };
-		000000000820 /* Mockingjay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Mockingjay.framework; path = Mockingjay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000820 /* Mockingjay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mockingjay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		000000000880 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		000000000930 /* Mockingjay.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Mockingjay.xcconfig; sourceTree = "<group>"; };
 		000000000940 /* Mockingjay.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Mockingjay.modulemap; sourceTree = "<group>"; };
@@ -310,14 +311,14 @@
 		000000000970 /* Mockingjay-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Mockingjay-Info.plist"; sourceTree = "<group>"; };
 		000000000980 /* Mockingjay-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Mockingjay-prefix.pch"; sourceTree = "<group>"; };
 		000000000990 /* Mockingjay-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Mockingjay-dummy.m"; sourceTree = "<group>"; };
-		0000000009F0 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0000000009F0 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		000000000EB0 /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
 		000000000EC0 /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
 		000000000ED0 /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
 		000000000EF0 /* Nimble-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Nimble-Info.plist"; sourceTree = "<group>"; };
 		000000000F00 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
 		000000000F10 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
-		000000000F70 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Quick.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000F70 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0000000011C0 /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
 		0000000011D0 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
 		0000000011E0 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
@@ -325,7 +326,7 @@
 		000000001210 /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
 		000000001220 /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
 		000000001290 /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
-		0000000012E0 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = URITemplate.framework; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0000000012E0 /* URITemplate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = URITemplate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		000000001360 /* URITemplate.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = URITemplate.xcconfig; sourceTree = "<group>"; };
 		000000001370 /* URITemplate.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = URITemplate.modulemap; sourceTree = "<group>"; };
 		000000001380 /* URITemplate-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-umbrella.h"; sourceTree = "<group>"; };
@@ -333,7 +334,7 @@
 		0000000013B0 /* URITemplate-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "URITemplate-prefix.pch"; sourceTree = "<group>"; };
 		0000000013C0 /* URITemplate-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "URITemplate-dummy.m"; sourceTree = "<group>"; };
 		0000000013E0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		000000001450 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Tests.framework; path = "Pods-Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000001450 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0000000014C0 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		0000000014D0 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		0000000014E0 /* Pods-Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tests-Info.plist"; sourceTree = "<group>"; };
@@ -452,7 +453,6 @@
 				000000000920 /* Support Files */,
 				000000000180 /* XCTest */,
 			);
-			name = Mockingjay;
 			path = Mockingjay;
 			sourceTree = "<group>";
 		};
@@ -530,7 +530,6 @@
 				000000000530 /* XCTestObservationCenter+Register.m */,
 				000000000EA0 /* Support Files */,
 			);
-			name = Nimble;
 			path = Nimble;
 			sourceTree = "<group>";
 		};
@@ -569,7 +568,6 @@
 				0000000007A0 /* XCTestSuite+QuickTestSuiteBuilder.m */,
 				0000000011B0 /* Support Files */,
 			);
-			name = Quick;
 			path = Quick;
 			sourceTree = "<group>";
 		};
@@ -578,7 +576,6 @@
 			children = (
 				000000001280 /* Support Files */,
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
@@ -588,7 +585,6 @@
 				0000000007D0 /* URITemplate.swift */,
 				000000001350 /* Support Files */,
 			);
-			name = URITemplate;
 			path = URITemplate;
 			sourceTree = "<group>";
 		};
@@ -868,14 +864,29 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					0000000007E0 = {
+						LastSwiftMigration = 1130;
+					};
+					0000000009B0 = {
+						LastSwiftMigration = 1130;
+					};
+					000000000F30 = {
+						LastSwiftMigration = 1130;
+					};
+					0000000012A0 = {
+						LastSwiftMigration = 1130;
+					};
+				};
 			};
 			buildConfigurationList = 000000000030 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 000000000010;
 			productRefGroup = 000000000020 /* Products */;
@@ -1111,6 +1122,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1175,6 +1187,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1224,8 +1237,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				SYMROOT = "${SRCROOT}/../build";
 			};

--- a/Example/Tests/Mocks/MockedConfiguration.swift
+++ b/Example/Tests/Mocks/MockedConfiguration.swift
@@ -10,13 +10,17 @@ import Cara
 
 class MockedConfiguration: Cara.Configuration {
     var baseURL: URL?
-    var headers: RequestHeaders?
     var publicKeys: PublicKeys?
     var loggers: [Logger]?
     
+    var mockedHeaders: RequestHeaders?
+    func headers(for request: Request) -> RequestHeaders? {
+        return mockedHeaders
+    }
+    
     init(baseURL: URL?, headers: RequestHeaders? = nil, publicKeys: PublicKeys? = nil) {
         self.baseURL = baseURL
-        self.headers = headers
+        self.mockedHeaders = headers
         self.publicKeys = publicKeys
     }
 }

--- a/Example/Tests/Mocks/MockedConfiguration.swift
+++ b/Example/Tests/Mocks/MockedConfiguration.swift
@@ -12,11 +12,15 @@ class MockedConfiguration: Cara.Configuration {
     var baseURL: URL?
     var publicKeys: PublicKeys?
     var loggers: [Logger]?    
-    var headers: RequestHeaders?
+    var mockedHeaders: RequestHeaders?
     
     init(baseURL: URL?, headers: RequestHeaders? = nil, publicKeys: PublicKeys? = nil) {
         self.baseURL = baseURL
-        self.headers = headers
+        self.mockedHeaders = headers
         self.publicKeys = publicKeys
+    }
+    
+    func headers(for request: Request) -> RequestHeaders? {
+        return mockedHeaders
     }
 }

--- a/Example/Tests/Mocks/MockedConfiguration.swift
+++ b/Example/Tests/Mocks/MockedConfiguration.swift
@@ -11,16 +11,12 @@ import Cara
 class MockedConfiguration: Cara.Configuration {
     var baseURL: URL?
     var publicKeys: PublicKeys?
-    var loggers: [Logger]?
-    
-    var mockedHeaders: RequestHeaders?
-    func headers(for request: Request) -> RequestHeaders? {
-        return mockedHeaders
-    }
+    var loggers: [Logger]?    
+    var headers: RequestHeaders?
     
     init(baseURL: URL?, headers: RequestHeaders? = nil, publicKeys: PublicKeys? = nil) {
         self.baseURL = baseURL
-        self.mockedHeaders = headers
+        self.headers = headers
         self.publicKeys = publicKeys
     }
 }

--- a/Example/Tests/Specs/Service/ServiceSpec.swift
+++ b/Example/Tests/Specs/Service/ServiceSpec.swift
@@ -93,7 +93,7 @@ class ServiceSpec: QuickSpec {
                     
                     let interceptor = MockedInterceptor()
                     interceptor.interceptHandle = { error, retry in
-                        configuration.mockedHeaders = ["Some": "Header"]
+                        configuration.headers = ["Some": "Header"]
                         self.stub(http(.get, uri: "https://relative.com/request"), http(200))
                         return false
                     }
@@ -114,7 +114,7 @@ class ServiceSpec: QuickSpec {
                     
                     let interceptor = MockedInterceptor()
                     interceptor.interceptHandle = { error, retry in
-                        configuration.mockedHeaders = ["Some": "Header"]
+                        configuration.headers = ["Some": "Header"]
                         self.stub(http(.get, uri: "https://relative.com/request"), http(200))
                         DispatchQueue.global().asyncAfter(deadline: .now() + 0.1, execute: retry)
                         return true
@@ -138,7 +138,7 @@ class ServiceSpec: QuickSpec {
                     var count: Int = 0
                     interceptor.interceptHandle = { error, retry in
                         count += 1
-                        configuration.mockedHeaders = ["Some": "Header"]
+                        configuration.headers = ["Some": "Header"]
                         if count > 1 {
                             // Make sure the second try also fails.
                             self.stub(http(.get, uri: "https://relative.com/request"), http(200))

--- a/Example/Tests/Specs/Service/ServiceSpec.swift
+++ b/Example/Tests/Specs/Service/ServiceSpec.swift
@@ -93,7 +93,7 @@ class ServiceSpec: QuickSpec {
                     
                     let interceptor = MockedInterceptor()
                     interceptor.interceptHandle = { error, retry in
-                        configuration.headers = ["Some": "Header"]
+                        configuration.mockedHeaders = ["Some": "Header"]
                         self.stub(http(.get, uri: "https://relative.com/request"), http(200))
                         return false
                     }
@@ -114,7 +114,7 @@ class ServiceSpec: QuickSpec {
                     
                     let interceptor = MockedInterceptor()
                     interceptor.interceptHandle = { error, retry in
-                        configuration.headers = ["Some": "Header"]
+                        configuration.mockedHeaders = ["Some": "Header"]
                         self.stub(http(.get, uri: "https://relative.com/request"), http(200))
                         DispatchQueue.global().asyncAfter(deadline: .now() + 0.1, execute: retry)
                         return true
@@ -138,7 +138,7 @@ class ServiceSpec: QuickSpec {
                     var count: Int = 0
                     interceptor.interceptHandle = { error, retry in
                         count += 1
-                        configuration.headers = ["Some": "Header"]
+                        configuration.mockedHeaders = ["Some": "Header"]
                         if count > 1 {
                             // Make sure the second try also fails.
                             self.stub(http(.get, uri: "https://relative.com/request"), http(200))

--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -14,10 +14,10 @@ public typealias PublicKeys = [String: String]
 public protocol Configuration {
     /// The base url that is appended to the `Request`'s relative url.
     var baseURL: URL? { get }
-    /// Set the headers that will be used for all the requests.
-    var headers: RequestHeaders? { get }
     /// Set the public keys for the hosts.
     var publicKeys: PublicKeys? { get }
     /// Set the loggers when you want to receive more information on the requests.
     var loggers: [Logger]? { get }
+    /// Set the headers that will be used for all the requests.
+    func headers(for request: Request) -> RequestHeaders?
 }

--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -19,5 +19,18 @@ public protocol Configuration {
     /// Set the loggers when you want to receive more information on the requests.
     var loggers: [Logger]? { get }
     /// Set the headers that will be used for all the requests.
+    @available(*, deprecated, renamed: "headers(for:)")
+    var headers: RequestHeaders? { get }
+    /// Set the headers that will be used for all the requests. The current request is passed
+    /// so that some additional logic can be applied before returning the headers.
+    ///
+    /// - parameters request: The current request.
     func headers(for request: Request) -> RequestHeaders?
+}
+
+public extension Configuration {
+    /// We manually override this method because we want to deprecate the use of `headers`.
+    func headers(for request: Request) -> RequestHeaders? {
+        return headers
+    }
 }

--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -18,19 +18,11 @@ public protocol Configuration {
     var publicKeys: PublicKeys? { get }
     /// Set the loggers when you want to receive more information on the requests.
     var loggers: [Logger]? { get }
-    /// Set the headers that will be used for all the requests.
-    @available(*, deprecated, renamed: "headers(for:)")
-    var headers: RequestHeaders? { get }
     /// Set the headers that will be used for all the requests. The current request is passed
     /// so that some additional logic can be applied before returning the headers.
     ///
     /// - parameters request: The current request.
+    ///
+    /// - return: The request headers.
     func headers(for request: Request) -> RequestHeaders?
-}
-
-public extension Configuration {
-    /// We manually override this method because we want to deprecate the use of `headers`.
-    func headers(for request: Request) -> RequestHeaders? {
-        return headers
-    }
 }

--- a/Sources/Request/Request+URLRequest.swift
+++ b/Sources/Request/Request+URLRequest.swift
@@ -52,7 +52,9 @@ extension Request {
     private func makeHeaders(with configuration: Configuration) -> RequestHeaders? {
         var requestHeaders: RequestHeaders?
         // When headers are available in the configuration we use them.
-        if let headers = configuration.headers { requestHeaders = headers }
+        if let headers = configuration.headers(for: self) {
+            requestHeaders = headers
+        }
         // When headers are available in this request we use them.
         if let headers = headers {
             requestHeaders = requestHeaders ?? RequestHeaders()

--- a/Sources/Service/PublicKeyPinningService.swift
+++ b/Sources/Service/PublicKeyPinningService.swift
@@ -54,7 +54,7 @@ class PublicKeyPinningService {
             
             var error: Unmanaged<CFError>?
             if let publicKeyData = SecKeyCopyExternalRepresentation(publicKey, &error) {
-                var keyWithHeader = Data(bytes: rsa2048Asn1Header)
+                var keyWithHeader = Data(rsa2048Asn1Header)
                 keyWithHeader.append(publicKeyData as Data)
                 let sha256 = keyWithHeader.sha256
                 // When the public keys don't match continue to the next certificate.
@@ -71,7 +71,8 @@ class PublicKeyPinningService {
 private extension Data {
     var sha256: Data {
         var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-        withUnsafeBytes { _ = CC_SHA256($0, CC_LONG(self.count), &hash) }
-        return Data(bytes: hash)
+        withUnsafeBytes { _ = CC_SHA256($0.baseAddress, CC_LONG(self.count), &hash) }
+        return Data(hash)
+
     }
 }


### PR DESCRIPTION
We want to know when fetching the headers from the `Configuration` which requests we are currently triggering. This is because sometimes we want to handle request based logic.