### PR TITLE
Update to swift-tools 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
If you create a new swift package with version `swift-tools-version 5.3` it can't handle dependencies with a lower swift version. 

I need version 5.3 since it supports Binary targets and version 5 doesn't seem to support this. 

Also when using spm in a dynamic sdk it provides you with a warning that the spm is not build for library evolution, thus "unstable".
This warning is gone when using version 5.3. 