### PR TITLE
47: URLAuthenticationChallenge always canceled when authentication me…

### DIFF
--- a/Sources/Service/NetworkService.swift
+++ b/Sources/Service/NetworkService.swift
@@ -85,7 +85,7 @@ extension NetworkService: URLSessionDataDelegate {
         guard
             let serverTrust = challenge.protectionSpace.serverTrust,
             challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust else {
-            completionHandler(.cancelAuthenticationChallenge, nil)
+            completionHandler(.performDefaultHandling, nil)
             return
         }
         


### PR DESCRIPTION
#47 URLAuthenticationChallenge always canceled when authentication method is not "server trust" 
